### PR TITLE
DEV-11: idempotent event inserts (Bet A workstream 1)

### DIFF
--- a/packages/backend/src/__test_helpers__/mockStubs.ts
+++ b/packages/backend/src/__test_helpers__/mockStubs.ts
@@ -15,13 +15,17 @@ import { mock } from "bun:test";
 export function dbStubs(overrides: Record<string, unknown> = {}) {
   const noop = mock(() => Promise.resolve(null));
   const noopArr = mock(() => Promise.resolve([]));
+  // insertEvent now returns { stored: boolean } so callers can branch on
+  // duplicate-id no-ops. Default the stub to "stored: true" so existing
+  // tests behave as before.
+  const insertEventStub = mock(() => Promise.resolve({ stored: true }));
   return {
     // queries.ts
     initializeDatabase: noop,
     upsertDeveloper: noop,
     createSession: noop,
     endSession: noop,
-    insertEvent: noop,
+    insertEvent: insertEventStub,
     getActiveAgents: noopArr,
     getActiveSessions: noopArr,
     getAllDevelopers: noopArr,

--- a/packages/backend/src/db/queries.ts
+++ b/packages/backend/src/db/queries.ts
@@ -72,11 +72,25 @@ export async function endSession(sql: SQL, id: string) {
   await sql`UPDATE sessions SET status = 'ended', ended_at = NOW() WHERE id = ${id}`;
 }
 
-export async function insertEvent(sql: SQL, event: DevscopeEvent) {
+/**
+ * Insert an event idempotently.
+ *
+ * Re-sending an event with an id that already exists in `events` is a no-op
+ * at the DB layer: the row is left untouched and `{ stored: false }` is
+ * returned so callers can skip post-insert side-effects (broadcasts,
+ * snapshots) and the plugin can clear its retry buffer for that id.
+ *
+ * Idempotency is guaranteed by `events.id PRIMARY KEY` + `ON CONFLICT DO
+ * NOTHING`. `RETURNING id` produces zero rows on conflict.
+ */
+export async function insertEvent(sql: SQL, event: DevscopeEvent): Promise<{ stored: boolean }> {
   const payload = event.payload ?? {};
-  await sql`
+  const rows = await sql`
     INSERT INTO events (id, session_id, event_type, payload, created_at)
-    VALUES (${event.id}, ${event.sessionId}, ${event.eventType}, ${payload}::jsonb, ${event.timestamp}::timestamptz)`;
+    VALUES (${event.id}, ${event.sessionId}, ${event.eventType}, ${payload}::jsonb, ${event.timestamp}::timestamptz)
+    ON CONFLICT (id) DO NOTHING
+    RETURNING id`;
+  return { stored: (rows as unknown[]).length > 0 };
 }
 
 export async function getActiveAgents(sql: SQL) {

--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -9,7 +9,7 @@ import { dbStubs, wsHandlerStubs, developerLinkStubs, stripSensitiveFieldsStubs 
 const mockUpsertDeveloper = mock(() => Promise.resolve());
 const mockCreateSession = mock(() => Promise.resolve());
 const mockEndSession = mock(() => Promise.resolve());
-const mockInsertEvent = mock(() => Promise.resolve());
+const mockInsertEvent = mock(() => Promise.resolve({ stored: true }));
 const mockGetRecentEvents = mock(() => Promise.resolve([] as any[]));
 const mockCheckAlertThresholds = mock(() => Promise.resolve(null as any));
 
@@ -157,7 +157,7 @@ describe("POST /events", () => {
     mockEndSession.mockReset();
     mockEndSession.mockImplementation(() => Promise.resolve());
     mockInsertEvent.mockReset();
-    mockInsertEvent.mockImplementation(() => Promise.resolve());
+    mockInsertEvent.mockImplementation(() => Promise.resolve({ stored: true }));
     mockCheckAlertThresholds.mockReset();
     mockCheckAlertThresholds.mockImplementation(() => Promise.resolve(null));
     mockBroadcastToOrg.mockReset();
@@ -334,6 +334,38 @@ describe("POST /events", () => {
       sessionId: "sess-1",
       eventType: "session.start",
     });
+  });
+
+  // -----------------------------------------------------------------------
+  // Idempotency (DEV-11 Bet A workstream 1)
+  // -----------------------------------------------------------------------
+
+  test("re-sending the same event id is a no-op (duplicate response, no broadcast)", async () => {
+    // Simulate ON CONFLICT DO NOTHING returning zero rows: the row already
+    // existed, so insertEvent reports stored: false. The handler must skip
+    // post-insert side-effects (broadcasts, snapshots) and signal duplicate
+    // back to the caller so the plugin can clear its retry buffer.
+    mockInsertEvent.mockImplementation(() => Promise.resolve({ stored: false }));
+
+    const sql = makeMockSql([], [{ organization_id: "org-1" }]);
+    const app = buildApp(sql);
+    const event = validEvent();
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, duplicate: true });
+
+    // The DB write was attempted (idempotency happens at the DB layer)
+    expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+
+    // ...but no broadcast happened because the event was already stored.
+    expect(mockBroadcastToOrg).not.toHaveBeenCalled();
   });
 
   // -----------------------------------------------------------------------

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -272,7 +272,16 @@ export function eventsRoutes(sql: SQL) {
       }
     }
 
-    await insertEvent(sql, event);
+    const { stored } = await insertEvent(sql, event);
+
+    // Idempotency: if a previous request already stored this event id, treat
+    // this call as a no-op. Skip broadcasts, snapshots, and ethics-stripped
+    // logging so a retried event does not double-fire side effects.
+    // Pre-insert side effects above (createSession, upsertDeveloper, ethics
+    // privacy_mode_activated) are already idempotent in their own right.
+    if (!stored) {
+      return c.json({ ok: true, duplicate: true });
+    }
 
     // Run shared post-insert handlers (broadcasts, compaction, snapshots, friction)
     const { devOrgs } = await runPostInsertHandlers(event, {
@@ -493,8 +502,12 @@ export function eventsRoutes(sql: SQL) {
       await createSession(sql, event.sessionId, event.developerId, event.projectPath, event.projectName, null, null);
     }
 
-    // Insert the event
-    await insertEvent(sql, event);
+    // Insert the event (idempotent: re-sending the same id is a no-op)
+    const { stored } = await insertEvent(sql, event);
+
+    if (!stored) {
+      return c.json({ ok: true, duplicate: true });
+    }
 
     // Run shared post-insert handlers (broadcasts, compaction, snapshots, friction)
     await runPostInsertHandlers(event, {


### PR DESCRIPTION
Workstream 1 of [Bet A](https://github.com/DowLucas/devscope/issues) — resilient & coherent ingestion. Issue: DEV-11.

## What changes

Re-sending an event with an id that already exists in `events` is now a true no-op.

- `insertEvent` uses `ON CONFLICT (id) DO NOTHING` and returns `{ stored: boolean }`.
- Both `POST /api/events` and `POST /api/events/hook` short-circuit on a duplicate with `{ ok: true, duplicate: true }` — no broadcasts, no snapshot side-effects, no double-counting.
- The `duplicate: true` flag gives the plugin a clean signal to drop the event id from its retry buffer (workstream 2 / DEV-23).

Pre-insert side-effects (`createSession`, `upsertDeveloper`, `privacy_mode_activated` ethics audit) were already idempotent and are left in place — their own `ON CONFLICT` clauses handle the read-modify-write race on session state.

## Why now

Plugin retries on transient network failures will become real once DEV-23 ships. Without idempotent inserts, a retried event would re-fire broadcasts and double-count snapshot side-effects. This change is the prerequisite that makes DEV-23 safe to deploy.

## Tests

- New focused test: "duplicate id is a no-op" — asserts the duplicate response shape and that no broadcast fires.
- Existing mocks/stubs updated to return `{ stored: true }` by default.
- Backend suite: 251 / 251 passing.

## Stacking note

DEV-24 is stacked on top of this branch (`feat/dev-24-single-developer-id` → `feat/dev-11-idempotent-insert`). Merge order: this PR first, then DEV-24 (after Lucas runs the migration dry-run).

## Risk

Low. The change is a one-line conflict clause + a duplicate short-circuit. No schema changes. No gate required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented duplicate event detection to safely handle resent events. Events with matching identifiers are now properly recognized and prevented from triggering redundant processing, such as unnecessary broadcasts and snapshot operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->