### PR TITLE
DEV-31: gate per-developer drill-down to self-only viewers

### DIFF
--- a/packages/backend/src/__test_helpers__/mockStubs.ts
+++ b/packages/backend/src/__test_helpers__/mockStubs.ts
@@ -37,6 +37,7 @@ export function dbStubs(overrides: Record<string, unknown> = {}) {
     getProjectActivity: noopArr,
     getTeamActivitySummary: noop,
     getHourlyDistribution: noopArr,
+    getSkillUsageBreakdown: noopArr,
     getActivityPerMinute: noopArr,
     getPeriodComparison: noop,
     getToolFailureRates: noopArr,

--- a/packages/backend/src/middleware/__tests__/selfDeveloperGate.test.ts
+++ b/packages/backend/src/middleware/__tests__/selfDeveloperGate.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { developerLinkStubs } from "../../__test_helpers__/mockStubs";
+
+// ---------------------------------------------------------------------------
+// Mocks – must be set up BEFORE importing the module under test
+// ---------------------------------------------------------------------------
+
+const mockGetAllDeveloperIdsForUser = mock(() =>
+  Promise.resolve([] as string[]),
+);
+
+mock.module("../../services/developerLink", () =>
+  developerLinkStubs({
+    getAllDeveloperIdsForUser: mockGetAllDeveloperIdsForUser,
+  }),
+);
+
+// Import AFTER mocks are registered
+const { gateSelfDeveloperId } = await import("../selfDeveloperGate");
+
+// ---------------------------------------------------------------------------
+// Helpers — mirror the makeContext pattern from orgScope.test.ts but also
+// model `req.query(name)` since the gate reads the developerId query param.
+// ---------------------------------------------------------------------------
+
+function makeContext(opts: {
+  query?: Record<string, string>;
+  vars?: Record<string, unknown>;
+}) {
+  const store = new Map<string, unknown>(Object.entries(opts.vars ?? {}));
+  const query = opts.query ?? {};
+
+  return {
+    get(key: string) {
+      return store.get(key);
+    },
+    set(key: string, value: unknown) {
+      store.set(key, value);
+    },
+    json(body: unknown, status?: number) {
+      return { __type: "response", body, status } as unknown as Response;
+    },
+    req: {
+      query(name: string) {
+        return query[name];
+      },
+    },
+  };
+}
+
+const fakeSql = {} as any;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockGetAllDeveloperIdsForUser.mockReset();
+  mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve([]));
+});
+
+describe("gateSelfDeveloperId", () => {
+  test("allows team-aggregate request when no developerId is set", async () => {
+    const c = makeContext({ query: {}, vars: { user: { id: "user-1" } } });
+    const result = await gateSelfDeveloperId(c as any, fakeSql);
+
+    expect(result.allow).toBe(true);
+    if (result.allow) expect(result.developerId).toBeUndefined();
+    // Must not even bother resolving viewer hashes when there's nothing to gate.
+    expect(mockGetAllDeveloperIdsForUser).not.toHaveBeenCalled();
+  });
+
+  test("allows when requester owns the requested developerId and it's in org", async () => {
+    mockGetAllDeveloperIdsForUser.mockImplementation(() =>
+      Promise.resolve(["dev-aaa"]),
+    );
+    const c = makeContext({
+      query: { developerId: "dev-aaa" },
+      vars: {
+        user: { id: "user-1" },
+        orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      },
+    });
+
+    const result = await gateSelfDeveloperId(c as any, fakeSql);
+
+    expect(result.allow).toBe(true);
+    if (result.allow) expect(result.developerId).toBe("dev-aaa");
+  });
+
+  test("denies (403) when requester does NOT own the requested developerId", async () => {
+    // Viewer owns dev-bbb but is asking for dev-aaa.
+    mockGetAllDeveloperIdsForUser.mockImplementation(() =>
+      Promise.resolve(["dev-bbb"]),
+    );
+    const c = makeContext({
+      query: { developerId: "dev-aaa" },
+      vars: {
+        user: { id: "user-2" },
+        orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      },
+    });
+
+    const result = (await gateSelfDeveloperId(c as any, fakeSql)) as {
+      allow: false;
+      response: { body: unknown; status: number };
+    };
+
+    expect(result.allow).toBe(false);
+    expect(result.response.status).toBe(403);
+    expect(result.response.body).toEqual({
+      error: "Per-developer detail is restricted to the developer themselves.",
+    });
+  });
+
+  test("denies (403) when no user is on the context (anonymous-like)", async () => {
+    const c = makeContext({
+      query: { developerId: "dev-aaa" },
+      vars: { orgDeveloperIds: ["dev-aaa"] },
+    });
+
+    const result = (await gateSelfDeveloperId(c as any, fakeSql)) as {
+      allow: false;
+      response: { status: number };
+    };
+
+    expect(result.allow).toBe(false);
+    expect(result.response.status).toBe(403);
+    // No user → no DB lookup, just 403.
+    expect(mockGetAllDeveloperIdsForUser).not.toHaveBeenCalled();
+  });
+
+  test("denies (403) when requested developerId is owned but not in the active org", async () => {
+    // Viewer is multi-org-linked: owns dev-aaa, but this active org only has dev-bbb.
+    mockGetAllDeveloperIdsForUser.mockImplementation(() =>
+      Promise.resolve(["dev-aaa", "dev-bbb"]),
+    );
+    const c = makeContext({
+      query: { developerId: "dev-aaa" },
+      vars: {
+        user: { id: "user-1" },
+        orgDeveloperIds: ["dev-bbb"], // dev-aaa not in this org
+      },
+    });
+
+    const result = (await gateSelfDeveloperId(c as any, fakeSql)) as {
+      allow: false;
+      response: { status: number };
+    };
+
+    expect(result.allow).toBe(false);
+    expect(result.response.status).toBe(403);
+  });
+
+  test("allows when org scoping is absent (orgDeveloperIds undefined)", async () => {
+    // Some routes may not have org scoping wired. Self-ownership alone is the gate.
+    mockGetAllDeveloperIdsForUser.mockImplementation(() =>
+      Promise.resolve(["dev-aaa"]),
+    );
+    const c = makeContext({
+      query: { developerId: "dev-aaa" },
+      vars: { user: { id: "user-1" } /* no orgDeveloperIds */ },
+    });
+
+    const result = await gateSelfDeveloperId(c as any, fakeSql);
+
+    expect(result.allow).toBe(true);
+    if (result.allow) expect(result.developerId).toBe("dev-aaa");
+  });
+});

--- a/packages/backend/src/middleware/selfDeveloperGate.ts
+++ b/packages/backend/src/middleware/selfDeveloperGate.ts
@@ -1,0 +1,62 @@
+import type { SQL } from "bun";
+import type { Context } from "hono";
+import { getAllDeveloperIdsForUser } from "../services/developerLink";
+
+/**
+ * Resolves a `developerId` query parameter for per-developer endpoints under
+ * a self-only access policy.
+ *
+ * Per the DevScope mission constraint (no individual surveillance, no
+ * leaderboard surfaces), per-developer breakdown data is restricted to the
+ * developer themselves. A non-self viewer asking for `developerId=X` is
+ * denied outright rather than silently downgraded — silent downgrade is
+ * misleading UX, and a clear 403 makes the policy explicit at the trust
+ * boundary.
+ *
+ * Returns:
+ *   - { allow: true, developerId: undefined } when no `developerId` is set
+ *     (caller renders team-aggregate data).
+ *   - { allow: true, developerId } when the requester owns that hash AND it
+ *     belongs to the active org.
+ *   - { allow: false, response } (a 403 JSON Response) otherwise — caller
+ *     should `return gate.response`.
+ */
+export type SelfDeveloperGateResult =
+  | { allow: true; developerId: string | undefined }
+  | { allow: false; response: Response };
+
+export async function gateSelfDeveloperId(
+  c: Context,
+  sql: SQL,
+): Promise<SelfDeveloperGateResult> {
+  const requested = c.req.query("developerId") || undefined;
+  if (!requested) return { allow: true, developerId: undefined };
+
+  const user = c.get("user" as never) as { id?: string } | undefined;
+  const orgDevIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
+
+  const viewerDevIds = user?.id
+    ? await getAllDeveloperIdsForUser(sql, user.id)
+    : [];
+
+  const ownedByViewer = viewerDevIds.includes(requested);
+  // If org scoping is in effect, the requested developer must also belong to
+  // the active org. When org scoping is absent (e.g. unscoped routes), only
+  // the self-ownership check applies.
+  const inOrg =
+    !orgDevIds || orgDevIds.length === 0 || orgDevIds.includes(requested);
+
+  if (!ownedByViewer || !inOrg) {
+    return {
+      allow: false,
+      response: c.json(
+        {
+          error:
+            "Per-developer detail is restricted to the developer themselves.",
+        },
+        403,
+      ),
+    };
+  }
+  return { allow: true, developerId: requested };
+}

--- a/packages/backend/src/routes/__tests__/export.test.ts
+++ b/packages/backend/src/routes/__tests__/export.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { dbStubs, developerLinkStubs } from "../../__test_helpers__/mockStubs";
+
+// ---------------------------------------------------------------------------
+// Mocks – set up BEFORE importing the module under test.
+// Covers DEV-31's CSV/JSON export gating; full gate semantics are tested in
+// middleware/__tests__/selfDeveloperGate.test.ts.
+// ---------------------------------------------------------------------------
+
+const mockGetExportData = mock(() => Promise.resolve([] as any[]));
+
+mock.module("../../db", () =>
+  dbStubs({
+    getExportData: mockGetExportData,
+  }),
+);
+
+const mockGetAllDeveloperIdsForUser = mock(() => Promise.resolve([] as string[]));
+
+mock.module("../../services/developerLink", () =>
+  developerLinkStubs({
+    getAllDeveloperIdsForUser: mockGetAllDeveloperIdsForUser,
+  }),
+);
+
+// Import AFTER mocks are registered
+const { exportRoutes } = await import("../export");
+
+const fakeSql = {} as any;
+
+function buildApp(opts: { orgDeveloperIds?: string[]; user?: any } = {}) {
+  const app = new Hono();
+  app.use("/export/*", async (c, next) => {
+    if (opts.orgDeveloperIds !== undefined) {
+      c.set("orgDeveloperIds" as never, opts.orgDeveloperIds as never);
+    }
+    if (opts.user !== undefined) {
+      c.set("user" as never, opts.user as never);
+    }
+    await next();
+  });
+  app.route("/export", exportRoutes(fakeSql));
+  return app;
+}
+
+beforeEach(() => {
+  mockGetExportData.mockReset();
+  mockGetExportData.mockImplementation(() =>
+    Promise.resolve([{ day: "2026-05-01", total: 1 }]),
+  );
+  mockGetAllDeveloperIdsForUser.mockReset();
+  mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve([]));
+});
+
+// ---------------------------------------------------------------------------
+// /export/:dataType/csv — self-or-deny gate (DEV-31)
+// ---------------------------------------------------------------------------
+
+describe("GET /export/:dataType/csv (self-or-deny gate)", () => {
+  test("returns team-aggregate CSV (200) when no developerId is set", async () => {
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/export/activity/csv");
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/csv");
+    expect(mockGetExportData).toHaveBeenCalledWith(
+      fakeSql,
+      "activity",
+      30,
+      undefined, // no developerId
+      ["dev-aaa", "dev-bbb"],
+    );
+  });
+
+  test("returns 403 when developerId is set but viewer does not own it", async () => {
+    mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve(["dev-bbb"]));
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-2" },
+    });
+
+    const res = await app.request("/export/activity/csv?developerId=dev-aaa");
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Per-developer detail is restricted to the developer themselves.",
+    });
+    expect(mockGetExportData).not.toHaveBeenCalled();
+  });
+
+  test("returns 200 with developerId-scoped CSV when viewer is self", async () => {
+    mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve(["dev-aaa"]));
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/export/activity/csv?developerId=dev-aaa");
+
+    expect(res.status).toBe(200);
+    expect(mockGetExportData).toHaveBeenCalledWith(
+      fakeSql,
+      "activity",
+      30,
+      "dev-aaa",
+      ["dev-aaa", "dev-bbb"],
+    );
+  });
+
+  test("returns 400 for invalid data type before applying the gate", async () => {
+    // The gate is applied AFTER the data-type validation. This documents the order.
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/export/bogus/csv?developerId=dev-aaa");
+
+    expect(res.status).toBe(400);
+    expect(mockGetAllDeveloperIdsForUser).not.toHaveBeenCalled();
+    expect(mockGetExportData).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /export/:dataType/json (self-or-deny gate)", () => {
+  test("returns 403 when developerId is set but viewer does not own it", async () => {
+    mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve([]));
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/export/activity/json?developerId=dev-aaa");
+
+    expect(res.status).toBe(403);
+    expect(mockGetExportData).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routes/__tests__/insights.test.ts
+++ b/packages/backend/src/routes/__tests__/insights.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import { dbStubs, developerLinkStubs } from "../../__test_helpers__/mockStubs";
+
+// ---------------------------------------------------------------------------
+// Mocks – set up BEFORE importing the module under test.
+// We exercise the gate end-to-end through a representative endpoint
+// (`/insights/activity`); the gate's full unit coverage lives in
+// middleware/__tests__/selfDeveloperGate.test.ts.
+// ---------------------------------------------------------------------------
+
+const mockGetDeveloperActivityOverTime = mock(() => Promise.resolve([] as any[]));
+
+mock.module("../../db", () =>
+  dbStubs({
+    getDeveloperActivityOverTime: mockGetDeveloperActivityOverTime,
+  }),
+);
+
+const mockGetAllDeveloperIdsForUser = mock(() => Promise.resolve([] as string[]));
+
+mock.module("../../services/developerLink", () =>
+  developerLinkStubs({
+    getAllDeveloperIdsForUser: mockGetAllDeveloperIdsForUser,
+  }),
+);
+
+// Import AFTER mocks are registered
+const { insightsRoutes } = await import("../insights");
+
+const fakeSql = {} as any;
+
+function buildApp(opts: { orgDeveloperIds?: string[]; user?: any } = {}) {
+  const app = new Hono();
+  app.use("/insights/*", async (c, next) => {
+    if (opts.orgDeveloperIds !== undefined) {
+      c.set("orgDeveloperIds" as never, opts.orgDeveloperIds as never);
+    }
+    if (opts.user !== undefined) {
+      c.set("user" as never, opts.user as never);
+    }
+    await next();
+  });
+  app.route("/insights", insightsRoutes(fakeSql));
+  return app;
+}
+
+beforeEach(() => {
+  mockGetDeveloperActivityOverTime.mockReset();
+  mockGetDeveloperActivityOverTime.mockImplementation(() => Promise.resolve([]));
+  mockGetAllDeveloperIdsForUser.mockReset();
+  mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve([]));
+});
+
+// ---------------------------------------------------------------------------
+// /insights/activity — self-or-deny gate (DEV-31)
+// ---------------------------------------------------------------------------
+
+describe("GET /insights/activity (self-or-deny gate)", () => {
+  test("returns team-aggregate (200) when no developerId is set", async () => {
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/insights/activity");
+
+    expect(res.status).toBe(200);
+    expect(mockGetDeveloperActivityOverTime).toHaveBeenCalledWith(
+      fakeSql,
+      undefined, // no developerId — team aggregate
+      30,
+      ["dev-aaa", "dev-bbb"],
+    );
+  });
+
+  test("returns 403 when developerId is set but viewer does not own it", async () => {
+    // Viewer owns dev-bbb, asks for dev-aaa.
+    mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve(["dev-bbb"]));
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-2" },
+    });
+
+    const res = await app.request("/insights/activity?developerId=dev-aaa");
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Per-developer detail is restricted to the developer themselves.",
+    });
+    // Must not have hit the DB query — the gate short-circuits.
+    expect(mockGetDeveloperActivityOverTime).not.toHaveBeenCalled();
+  });
+
+  test("returns 200 with developerId-scoped data when viewer is self", async () => {
+    mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve(["dev-aaa"]));
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request("/insights/activity?developerId=dev-aaa&days=14");
+
+    expect(res.status).toBe(200);
+    expect(mockGetDeveloperActivityOverTime).toHaveBeenCalledWith(
+      fakeSql,
+      "dev-aaa",
+      14,
+      ["dev-aaa", "dev-bbb"],
+    );
+  });
+
+  test("returns 403 when developerId is set but no user on context", async () => {
+    const app = buildApp({ orgDeveloperIds: ["dev-aaa"] });
+
+    const res = await app.request("/insights/activity?developerId=dev-aaa");
+
+    expect(res.status).toBe(403);
+    expect(mockGetDeveloperActivityOverTime).not.toHaveBeenCalled();
+  });
+});

--- a/packages/backend/src/routes/export.ts
+++ b/packages/backend/src/routes/export.ts
@@ -3,6 +3,7 @@ import type { SQL } from "bun";
 import { z } from "zod";
 import { zValidator } from "@hono/zod-validator";
 import { getExportData, getDigests, generateDigest } from "../db";
+import { gateSelfDeveloperId } from "../middleware/selfDeveloperGate";
 
 const digestGenerateSchema = z.object({
   period_start: z.string().min(1).max(50),
@@ -43,13 +44,11 @@ export function exportRoutes(sql: SQL) {
     if (!VALID_EXPORT_TYPES.includes(dataType)) {
       return c.json({ error: `Invalid data type. Must be one of: ${VALID_EXPORT_TYPES.join(", ")}` }, 400);
     }
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const days = clampInt(c.req.query("days"), 30, 365);
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
-    const data = await getExportData(sql, dataType, days, developerId, devIds);
+    const data = await getExportData(sql, dataType, days, gate.developerId, devIds);
     const csv = toCsv(data as Record<string, unknown>[]);
     c.header("Content-Type", "text/csv");
     c.header("Content-Disposition", `attachment; filename="${dataType}-export.csv"`);
@@ -61,13 +60,11 @@ export function exportRoutes(sql: SQL) {
     if (!VALID_EXPORT_TYPES.includes(dataType)) {
       return c.json({ error: `Invalid data type. Must be one of: ${VALID_EXPORT_TYPES.join(", ")}` }, 400);
     }
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const days = clampInt(c.req.query("days"), 30, 365);
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
-    const data = await getExportData(sql, dataType, days, developerId, devIds);
+    const data = await getExportData(sql, dataType, days, gate.developerId, devIds);
     c.header("Content-Disposition", `attachment; filename="${dataType}-export.json"`);
     return c.json(data);
   });

--- a/packages/backend/src/routes/insights.ts
+++ b/packages/backend/src/routes/insights.ts
@@ -20,6 +20,7 @@ import {
   getSessionTokenUsageSummary,
   getSessionTokenUsageOverTime,
 } from "../db";
+import { gateSelfDeveloperId } from "../middleware/selfDeveloperGate";
 
 function clampInt(val: string | undefined, def: number, max: number): number {
   if (!val) return def;
@@ -37,73 +38,59 @@ export function insightsRoutes(sql: SQL) {
   });
 
   app.get("/activity", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined; // Not in org, ignore
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getDeveloperActivityOverTime(sql, developerId, days, devIds));
+    return c.json(await getDeveloperActivityOverTime(sql, gate.developerId, days, devIds));
   });
 
   app.get("/tools", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getToolUsageBreakdown(sql, developerId, days, devIds));
+    return c.json(await getToolUsageBreakdown(sql, gate.developerId, days, devIds));
   });
 
   app.get("/sessions", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getSessionStats(sql, developerId, days, devIds));
+    return c.json(await getSessionStats(sql, gate.developerId, days, devIds));
   });
 
   app.get("/sessions/summary", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getSessionStatsSummary(sql, developerId, days, devIds));
+    return c.json(await getSessionStatsSummary(sql, gate.developerId, days, devIds));
   });
 
   app.get("/projects", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getProjectActivity(sql, developerId, days, devIds));
+    return c.json(await getProjectActivity(sql, gate.developerId, days, devIds));
   });
 
   app.get("/skills", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getSkillUsageBreakdown(sql, developerId, days, devIds));
+    return c.json(await getSkillUsageBreakdown(sql, gate.developerId, days, devIds));
   });
 
   app.get("/hourly", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
     const days = clampInt(c.req.query("days"), 30, 365);
-    return c.json(await getHourlyDistribution(sql, developerId, days, devIds));
+    return c.json(await getHourlyDistribution(sql, gate.developerId, days, devIds));
   });
 
   app.get("/activity-per-minute", async (c) => {
@@ -114,24 +101,20 @@ export function insightsRoutes(sql: SQL) {
 
   // --- Period Comparison ---
   app.get("/period-comparison", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const days = clampInt(c.req.query("days"), 7, 365);
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
-    return c.json(await getPeriodComparison(sql, days, developerId, devIds));
+    return c.json(await getPeriodComparison(sql, days, gate.developerId, devIds));
   });
 
   // --- Failure Analysis ---
   app.get("/failures", async (c) => {
+    const gate = await gateSelfDeveloperId(c, sql);
+    if (!gate.allow) return gate.response;
     const days = clampInt(c.req.query("days"), 30, 365);
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
-    let developerId = c.req.query("developerId") || undefined;
-    if (developerId && devIds && devIds.length > 0 && !devIds.includes(developerId)) {
-      developerId = undefined;
-    }
-    return c.json(await getToolFailureRates(sql, days, developerId, devIds));
+    return c.json(await getToolFailureRates(sql, days, gate.developerId, devIds));
   });
 
   app.get("/failure-clusters", async (c) => {

--- a/packages/dashboard/src/components/insights/DeveloperDrillDown.tsx
+++ b/packages/dashboard/src/components/insights/DeveloperDrillDown.tsx
@@ -8,6 +8,7 @@ import type {
 } from "@devscope/shared";
 import { useInsightsData } from "@/hooks/useInsightsData";
 import { useDateRange } from "@/hooks/useDateRange";
+import { useMyDeveloperIds } from "@/hooks/useMyDeveloperIds";
 import { DateRangePicker } from "@/components/ui/date-range-picker";
 import { ExportButton } from "@/components/ui/export-button";
 import { StatCards } from "./StatCards";
@@ -17,7 +18,7 @@ import { SessionStatsChart } from "./charts/SessionStatsChart";
 import { ProjectActivityChart } from "./charts/ProjectActivityChart";
 import { HourlyHeatmap } from "./charts/HourlyHeatmap";
 import { PeriodComparison } from "./PeriodComparison";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Lock } from "lucide-react";
 
 interface DeveloperDrillDownProps {
   developerId: string;
@@ -29,7 +30,73 @@ export function DeveloperDrillDown({
   onBack,
 }: DeveloperDrillDownProps) {
   const { days } = useDateRange();
+  const { ids: myDeveloperIds, loading: myIdsLoading } = useMyDeveloperIds();
 
+  // Self-only gate (DEV-31, mission constraint): per-developer breakdown is
+  // visible only to the developer themselves. The backend enforces this with
+  // a 403; the frontend gate avoids issuing a flurry of doomed requests and
+  // gives the viewer a clear explanation instead of an error state.
+  const isSelfView = myDeveloperIds.has(developerId);
+
+  if (myIdsLoading) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to overview
+          </button>
+        </div>
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      </div>
+    );
+  }
+
+  if (!isSelfView) {
+    return (
+      <div className="space-y-6">
+        <div className="flex items-center gap-3">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Back to overview
+          </button>
+        </div>
+        <div className="rounded-lg border border-border bg-card p-6">
+          <div className="flex items-start gap-3">
+            <Lock className="h-5 w-5 mt-0.5 text-muted-foreground" />
+            <div className="space-y-1">
+              <div className="font-medium text-foreground">
+                Per-developer detail is self-view only
+              </div>
+              <p className="text-sm text-muted-foreground">
+                Per-session, per-tool, and per-hour breakdowns are visible only
+                to the developer themselves. DevScope is built for team
+                workflow visibility, not individual surveillance — there is no
+                cross-developer drill-down or leaderboard surface.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return <DeveloperDrillDownDetail developerId={developerId} onBack={onBack} days={days} />;
+}
+
+interface DetailProps {
+  developerId: string;
+  onBack: () => void;
+  days: number;
+}
+
+function DeveloperDrillDownDetail({ developerId, onBack, days }: DetailProps) {
   const summary = useInsightsData<SessionStatsSummary>("sessions/summary", developerId, days);
   const activity = useInsightsData<ActivityDataPoint[]>("activity", developerId, days);
   const tools = useInsightsData<ToolUsageDataPoint[]>("tools", developerId, days);

--- a/packages/dashboard/src/hooks/useMyDeveloperIds.ts
+++ b/packages/dashboard/src/hooks/useMyDeveloperIds.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react";
+import { apiFetch } from "@/lib/api";
+import { authClient } from "@/lib/auth-client";
+
+interface LinkedDeveloper {
+  developer_id: string;
+  name: string;
+  email: string;
+}
+
+interface State {
+  ids: Set<string>;
+  loading: boolean;
+}
+
+/**
+ * Returns the set of developer hashes linked to the currently signed-in user
+ * within the active organization. Used to gate "self-only" surfaces such as
+ * `DeveloperDrillDown` (DEV-31): per-developer breakdown is restricted to the
+ * developer themselves.
+ *
+ * The actual access decision is enforced by the backend; this hook exists so
+ * the dashboard can render a self-only notice instead of a permanent error
+ * state when a non-self viewer would land on a per-developer surface.
+ */
+export function useMyDeveloperIds(): State {
+  const { data: activeOrg } = authClient.useActiveOrganization();
+  const activeOrgId = activeOrg?.id ?? null;
+
+  const [ids, setIds] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!activeOrgId) {
+      setIds(new Set());
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    apiFetch("/api/teams/my-linked-developers")
+      .then(async (res) => {
+        if (!res.ok) return [] as LinkedDeveloper[];
+        return (await res.json()) as LinkedDeveloper[];
+      })
+      .then((rows) => {
+        if (cancelled) return;
+        setIds(new Set(rows.map((r) => r.developer_id)));
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setIds(new Set());
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeOrgId]);
+
+  return { ids, loading };
+}

--- a/packages/dashboard/src/hooks/useMyDeveloperIds.ts
+++ b/packages/dashboard/src/hooks/useMyDeveloperIds.ts
@@ -13,6 +13,13 @@ interface State {
   loading: boolean;
 }
 
+interface FetchedData {
+  orgId: string;
+  ids: Set<string>;
+}
+
+const EMPTY_IDS: Set<string> = new Set();
+
 /**
  * Returns the set of developer hashes linked to the currently signed-in user
  * within the active organization. Used to gate "self-only" surfaces such as
@@ -27,17 +34,14 @@ export function useMyDeveloperIds(): State {
   const { data: activeOrg } = authClient.useActiveOrganization();
   const activeOrgId = activeOrg?.id ?? null;
 
-  const [ids, setIds] = useState<Set<string>>(new Set());
-  const [loading, setLoading] = useState(true);
+  // Cache the most recent successful fetch keyed by orgId. Loading and empty
+  // states are derived from (activeOrgId, data) rather than synced via
+  // setState in the effect body — this avoids react-hooks/set-state-in-effect.
+  const [data, setData] = useState<FetchedData | null>(null);
 
   useEffect(() => {
-    if (!activeOrgId) {
-      setIds(new Set());
-      setLoading(false);
-      return;
-    }
+    if (!activeOrgId) return;
     let cancelled = false;
-    setLoading(true);
     apiFetch("/api/teams/my-linked-developers")
       .then(async (res) => {
         if (!res.ok) return [] as LinkedDeveloper[];
@@ -45,18 +49,23 @@ export function useMyDeveloperIds(): State {
       })
       .then((rows) => {
         if (cancelled) return;
-        setIds(new Set(rows.map((r) => r.developer_id)));
-        setLoading(false);
+        setData({
+          orgId: activeOrgId,
+          ids: new Set(rows.map((r) => r.developer_id)),
+        });
       })
       .catch(() => {
         if (cancelled) return;
-        setIds(new Set());
-        setLoading(false);
+        setData({ orgId: activeOrgId, ids: new Set() });
       });
     return () => {
       cancelled = true;
     };
   }, [activeOrgId]);
 
-  return { ids, loading };
+  if (!activeOrgId) return { ids: EMPTY_IDS, loading: false };
+  if (!data || data.orgId !== activeOrgId) {
+    return { ids: EMPTY_IDS, loading: true };
+  }
+  return { ids: data.ids, loading: false };
 }


### PR DESCRIPTION
## Summary

Closes DEV-31 (M5 from DEV-29 pilot-readiness audit — *most material finding*).

`DeveloperDrillDown` previously exposed per-session / per-tool / per-hour breakdowns plus CSV export to any org admin, enabling a manual leaderboard. This PR enforces the mission constraint by gating the underlying insights/export endpoints to **self-only** viewers at the trust boundary.

### Approach

- New `selfDeveloperGate` middleware (`packages/backend/src/middleware/selfDeveloperGate.ts`) checks the requested developer hash against the caller's own developer hashes (owns-hash AND in-org). Returns explicit **403** (not silent aggregate) when a non-self viewer requests another developer's data.
- Applied uniformly across 9 insights routes and both export formats (`/export/csv`, `/export/json`).
- New `useMyDeveloperIds` dashboard hook resolves the viewer's own developer hashes; `DeveloperDrillDown` only renders detail / CSV button when viewing self, otherwise shows aggregate-only recency view.

### Tests

- `selfDeveloperGate.test.ts` — allow / deny / no-user / ordering paths.
- `insights.test.ts` and `export.test.ts` — endpoint-level gating coverage.

### Acceptance (all met)

- [x] Non-self admin sees no per-session / per-tool / per-hour breakdown and no CSV export.
- [x] Developer viewing self sees full detail.
- [x] CSV export gated for non-self views.
- [x] Mission-test sweep: no leaderboard-shaped surface remaining on Developers/Topology.

CEO sign-off recorded on DEV-31. Watchtower will auto-deploy on merge.

## Test plan

- [x] Unit: `selfDeveloperGate` middleware allow/deny paths
- [x] Integration: insights routes return 403 for non-self
- [x] Integration: export routes return 403 for non-self
- [ ] Post-deploy smoke: confirm admin viewing another dev hits 403, dev viewing self gets full detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>