### PR TITLE
DEV-33: org-deletion operator script for consent-revoke

### DIFF
--- a/packages/backend/docs/operations.md
+++ b/packages/backend/docs/operations.md
@@ -1,0 +1,31 @@
+# Backend operations runbook
+
+## Consent revoke — delete an organization's data
+
+When a pilot revokes consent and asks for their data to be removed, run the
+operator script below from the backend package. It performs every required
+DELETE inside a single transaction and post-checks for residual rows.
+
+```bash
+# 1. Confirm what will be removed (transaction is rolled back).
+DATABASE_URL=postgres://... \
+  bun run packages/backend/scripts/delete-org.ts <organizationId> --dry-run
+
+# 2. Execute the deletion.
+DATABASE_URL=postgres://... \
+  bun run packages/backend/scripts/delete-org.ts <organizationId> --yes
+
+# 3. Verify zero residual rows (separate read-only check).
+DATABASE_URL=postgres://... \
+  bun run packages/backend/scripts/delete-org.ts <organizationId> --verify
+```
+
+Expected duration: under 30 seconds for a typical pilot org (a few thousand
+events). The script reports `committed` plus per-table delete counts on
+success, and exits non-zero with `RESIDUAL ROWS DETECTED` if anything
+survived. The script does NOT touch `auth_user` accounts or API keys (those
+are user-scoped, not org-scoped); a user requesting full account deletion
+must additionally hit `DELETE /api/account`.
+
+See `packages/backend/scripts/delete-org.ts` for the table-by-table audit
+that drives the deletion order.

--- a/packages/backend/scripts/__tests__/delete-org.test.ts
+++ b/packages/backend/scripts/__tests__/delete-org.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Integration test for delete-org.ts.
+ *
+ * Gated on TEST_DATABASE_URL — the unit suite has no live DB.  To run:
+ *
+ *   TEST_DATABASE_URL=postgres://devscope:devscope@localhost:5432/devscope_test \
+ *     bun test packages/backend/scripts/__tests__/delete-org.test.ts
+ *
+ * The test seeds a minimal but representative org across every org-scoped
+ * table, runs the deletion plan, and asserts zero residual rows. If the
+ * env var is unset the suite is skipped.
+ */
+import { describe, expect, test } from "bun:test";
+import { SQL } from "bun";
+import { initializeDatabase } from "../../src/db/schema";
+
+const dbUrl = process.env.TEST_DATABASE_URL;
+const d = dbUrl ? describe : describe.skip;
+
+d("delete-org integration", () => {
+  test("hard-deletes every org-scoped row across all tables", async () => {
+    const sql = await initializeDatabase(dbUrl!);
+    const orgId = `t-org-${crypto.randomUUID()}`;
+    const userId = `t-user-${crypto.randomUUID()}`;
+    const devId = `t-dev-${crypto.randomUUID()}`;
+    const sessionId = `t-sess-${crypto.randomUUID()}`;
+    const otherOrgId = `t-org-other-${crypto.randomUUID()}`;
+    const sharedDevId = `t-dev-shared-${crypto.randomUUID()}`;
+
+    // ---- seed ----
+    await sql`INSERT INTO auth_user (id, name, email) VALUES (${userId}, 'T', ${`${userId}@e.x`})`;
+    await sql`INSERT INTO organization (id, name, slug) VALUES (${orgId}, 'T', ${orgId})`;
+    await sql`INSERT INTO organization (id, name, slug) VALUES (${otherOrgId}, 'O', ${otherOrgId})`;
+    await sql`INSERT INTO organization_settings (organization_id) VALUES (${orgId})`;
+    await sql`INSERT INTO member (id, "organizationId", "userId", role) VALUES (${`m-${orgId}`}, ${orgId}, ${userId}, 'owner')`;
+    await sql`INSERT INTO invitation (id, "organizationId", email, role, "inviterId", "expiresAt") VALUES (${`i-${orgId}`}, ${orgId}, 'p@x.io', 'member', ${userId}, NOW() + INTERVAL '7 days')`;
+    await sql`INSERT INTO developers (id, name, email) VALUES (${devId}, 'D', ${`${devId}@e.x`})`;
+    await sql`INSERT INTO developers (id, name, email) VALUES (${sharedDevId}, 'S', ${`${sharedDevId}@e.x`})`;
+    await sql`INSERT INTO organization_developer (organization_id, developer_id) VALUES (${orgId}, ${devId})`;
+    // shared dev is in BOTH orgs and must NOT be deleted
+    await sql`INSERT INTO organization_developer (organization_id, developer_id) VALUES (${orgId}, ${sharedDevId})`;
+    await sql`INSERT INTO organization_developer (organization_id, developer_id) VALUES (${otherOrgId}, ${sharedDevId})`;
+    await sql`INSERT INTO user_developer_link (auth_user_id, developer_id) VALUES (${userId}, ${devId})`;
+
+    await sql`INSERT INTO sessions (id, developer_id, project_path, project_name) VALUES (${sessionId}, ${devId}, '/p', 'p')`;
+    await sql`INSERT INTO events (id, session_id, event_type, payload) VALUES (${`e1-${sessionId}`}, ${sessionId}, 'tool.use', '{}'::jsonb)`;
+    await sql`INSERT INTO session_titles (id, session_id, title) VALUES (${`st-${sessionId}`}, ${sessionId}, 't')`;
+
+    // patterns / anti-patterns matches (session_id linkage)
+    await sql`INSERT INTO session_patterns (id, name, description, tool_sequence) VALUES ('p-x', 'p', 'd', ARRAY['Bash'])`.catch(()=>{});
+    await sql`INSERT INTO session_pattern_matches (id, session_id, pattern_id) VALUES (${`spm-${sessionId}`}, ${sessionId}, 'p-x')`.catch(()=>{});
+    await sql`INSERT INTO anti_patterns (id, name, description, detection_rule, suggestion) VALUES ('ap-x', 'a', 'd', 'r', 's')`.catch(()=>{});
+    await sql`INSERT INTO session_anti_pattern_matches (id, session_id, anti_pattern_id) VALUES (${`sapm-${sessionId}`}, ${sessionId}, 'ap-x')`.catch(()=>{});
+
+    // org-scoped derived tables
+    await sql`INSERT INTO alert_rules (id, organization_id, rule_type) VALUES (${`ar-${orgId}`}, ${orgId}, 'failure_threshold')`;
+    await sql`INSERT INTO alert_events (id, rule_id, session_id, developer_id, tool_name, failure_count, organization_id) VALUES (${`ae-${orgId}`}, ${`ar-${orgId}`}, ${sessionId}, ${devId}, 'Bash', 1, ${orgId})`;
+    await sql`INSERT INTO digests (id, digest_type, period_start, period_end, organization_id) VALUES (${`dg-${orgId}`}, 'daily', NOW(), NOW(), ${orgId})`;
+    await sql`INSERT INTO ai_conversations (id, title, organization_id) VALUES (${`aic-${orgId}`}, 't', ${orgId})`;
+    await sql`INSERT INTO ai_messages (id, conversation_id, role, content) VALUES (${`aim-${orgId}`}, ${`aic-${orgId}`}, 'user', 'hi')`;
+    await sql`INSERT INTO ai_insights (id, type, severity, title, narrative, organization_id) VALUES (${`aii-${orgId}`}, 'trend', 'info', 't', 'n', ${orgId})`;
+    await sql`INSERT INTO ai_reports (id, report_type, title, organization_id) VALUES (${`air-${orgId}`}, 'daily', 't', ${orgId})`;
+    await sql`INSERT INTO ai_token_usage (id, source, model, organization_id) VALUES (${`aitu-${orgId}`}, 's', 'm', ${orgId})`;
+    await sql`INSERT INTO team_skills (id, organization_id, name, description, skill_body) VALUES (${`ts-${orgId}`}, ${orgId}, 'n', 'd', 'b')`;
+    await sql`INSERT INTO team_tool_topology (id, organization_id, tool_name, period_start, period_end) VALUES (${`ttt-${orgId}`}, ${orgId}, 'Bash', NOW(), NOW())`;
+    await sql`INSERT INTO team_skill_gaps (id, organization_id, tool_name, gap_type, description) VALUES (${`tsg-${orgId}`}, ${orgId}, 'Bash', 'low_proficiency', 'd')`;
+    await sql`INSERT INTO tooling_health_snapshots (id, organization_id, tool_name) VALUES (${`ths-${orgId}`}, ${orgId}, 'Bash')`;
+    await sql`INSERT INTO retention_log (id, organization_id) VALUES (${`rl-${orgId}`}, ${orgId})`;
+    await sql`INSERT INTO data_requests (id, developer_id, organization_id, request_type) VALUES (${`dr-${orgId}`}, ${devId}, ${orgId}, 'deletion')`;
+    await sql`INSERT INTO friction_rules (id, organization_id, rule_name, rule_type) VALUES (${`fr-${orgId}`}, ${orgId}, 'r', 'spike')`;
+    await sql`INSERT INTO friction_alerts (id, organization_id, session_id, developer_id, rule_type, title, description) VALUES (${`fa-${orgId}`}, ${orgId}, ${sessionId}, ${devId}, 'spike', 't', 'd')`;
+    await sql`INSERT INTO ethics_audit_log (id, organization_id, event_type) VALUES (${`eal-${orgId}`}, ${orgId}, 'sensitive_fields_stripped')`;
+    await sql`INSERT INTO claude_md_snapshots (id, organization_id, project_name, project_path, content_hash, content_size, session_id, developer_id) VALUES (${`cms-${orgId}`}, ${orgId}, 'p', '/p', 'h', 0, ${sessionId}, ${devId})`;
+    await sql`INSERT INTO claude_md_correlations (id, organization_id, project_path, snapshot_id, window_start, window_end) VALUES (${`cmc-${orgId}`}, ${orgId}, '/p', ${`cms-${orgId}`}, NOW(), NOW())`;
+    await sql`INSERT INTO workflow_profiles (id, organization_id, developer_id, period_start, period_end) VALUES (${`wp-${orgId}`}, ${orgId}, ${devId}, NOW(), NOW())`;
+
+    // ---- run deletion script ----
+    const proc = Bun.spawn(
+      [
+        "bun",
+        "run",
+        new URL("../delete-org.ts", import.meta.url).pathname,
+        orgId,
+        "--yes",
+      ],
+      { env: { ...process.env, DATABASE_URL: dbUrl! } },
+    );
+    const stdout = await new Response(proc.stdout).text();
+    const stderr = await new Response(proc.stderr).text();
+    const exit = await proc.exited;
+    expect({ exit, stdout, stderr }).toMatchObject({ exit: 0 });
+
+    // ---- assertions: zero residual rows everywhere ----
+    const tables = [
+      "organization",
+      "member",
+      "invitation",
+      "organization_developer",
+      "organization_settings",
+      "alert_rules",
+      "digests",
+      "ai_conversations",
+      "ai_insights",
+      "ai_reports",
+      "ai_token_usage",
+      "team_skills",
+      "team_tool_topology",
+      "team_skill_gaps",
+      "tooling_health_snapshots",
+      "retention_log",
+      "data_requests",
+      "friction_rules",
+      "friction_alerts",
+      "ethics_audit_log",
+      "claude_md_snapshots",
+      "claude_md_correlations",
+      "workflow_profiles",
+    ];
+    for (const t of tables) {
+      const col = t === "organization" ? "id" : t === "member" || t === "invitation" ? `"organizationId"` : "organization_id";
+      const rows = (await sql.unsafe(
+        `SELECT COUNT(*)::int AS n FROM ${t} WHERE ${col} = $1`,
+        [orgId],
+      )) as Array<{ n: number }>;
+      expect({ table: t, n: rows[0].n }).toEqual({ table: t, n: 0 });
+    }
+
+    // sole-org developer is gone, shared dev survives
+    const devLeft = (await sql`SELECT id FROM developers WHERE id = ${devId}`) as Array<unknown>;
+    expect(devLeft).toHaveLength(0);
+    const sharedLeft = (await sql`SELECT id FROM developers WHERE id = ${sharedDevId}`) as Array<unknown>;
+    expect(sharedLeft).toHaveLength(1);
+
+    // session/event tree gone
+    const sessLeft = (await sql`SELECT id FROM sessions WHERE id = ${sessionId}`) as Array<unknown>;
+    expect(sessLeft).toHaveLength(0);
+    const evLeft = (await sql`SELECT id FROM events WHERE session_id = ${sessionId}`) as Array<unknown>;
+    expect(evLeft).toHaveLength(0);
+
+    // user account NOT touched
+    const userLeft = (await sql`SELECT id FROM auth_user WHERE id = ${userId}`) as Array<unknown>;
+    expect(userLeft).toHaveLength(1);
+
+    // cleanup the other org we created
+    await sql`DELETE FROM organization_developer WHERE organization_id = ${otherOrgId}`;
+    await sql`DELETE FROM developers WHERE id = ${sharedDevId}`;
+    await sql`DELETE FROM organization WHERE id = ${otherOrgId}`;
+    await sql`DELETE FROM auth_user WHERE id = ${userId}`;
+
+    await sql.close();
+  }, 30_000);
+});

--- a/packages/backend/scripts/__tests__/delete-org.test.ts
+++ b/packages/backend/scripts/__tests__/delete-org.test.ts
@@ -27,6 +27,7 @@ d("delete-org integration", () => {
     const otherOrgId = `t-org-other-${crypto.randomUUID()}`;
     const sharedDevId = `t-dev-shared-${crypto.randomUUID()}`;
 
+    try {
     // ---- seed ----
     await sql`INSERT INTO auth_user (id, name, email) VALUES (${userId}, 'T', ${`${userId}@e.x`})`;
     await sql`INSERT INTO organization (id, name, slug) VALUES (${orgId}, 'T', ${orgId})`;
@@ -47,10 +48,13 @@ d("delete-org integration", () => {
     await sql`INSERT INTO session_titles (id, session_id, title) VALUES (${`st-${sessionId}`}, ${sessionId}, 't')`;
 
     // patterns / anti-patterns matches (session_id linkage)
-    await sql`INSERT INTO session_patterns (id, name, description, tool_sequence) VALUES ('p-x', 'p', 'd', ARRAY['Bash'])`.catch(()=>{});
-    await sql`INSERT INTO session_pattern_matches (id, session_id, pattern_id) VALUES (${`spm-${sessionId}`}, ${sessionId}, 'p-x')`.catch(()=>{});
-    await sql`INSERT INTO anti_patterns (id, name, description, detection_rule, suggestion) VALUES ('ap-x', 'a', 'd', 'r', 's')`.catch(()=>{});
-    await sql`INSERT INTO session_anti_pattern_matches (id, session_id, anti_pattern_id) VALUES (${`sapm-${sessionId}`}, ${sessionId}, 'ap-x')`.catch(()=>{});
+    // Parent rows ('p-x', 'ap-x') are shared across test runs — ON CONFLICT
+    // makes the seed idempotent without silently swallowing real errors.
+    // The match rows use unique session-scoped IDs and must insert cleanly.
+    await sql`INSERT INTO session_patterns (id, name, description, tool_sequence) VALUES ('p-x', 'p', 'd', ARRAY['Bash']) ON CONFLICT (id) DO NOTHING`;
+    await sql`INSERT INTO session_pattern_matches (id, session_id, pattern_id) VALUES (${`spm-${sessionId}`}, ${sessionId}, 'p-x')`;
+    await sql`INSERT INTO anti_patterns (id, name, description, detection_rule, suggestion) VALUES ('ap-x', 'a', 'd', 'r', 's') ON CONFLICT (id) DO NOTHING`;
+    await sql`INSERT INTO session_anti_pattern_matches (id, session_id, anti_pattern_id) VALUES (${`sapm-${sessionId}`}, ${sessionId}, 'ap-x')`;
 
     // org-scoped derived tables
     await sql`INSERT INTO alert_rules (id, organization_id, rule_type) VALUES (${`ar-${orgId}`}, ${orgId}, 'failure_threshold')`;
@@ -83,10 +87,12 @@ d("delete-org integration", () => {
         orgId,
         "--yes",
       ],
-      { env: { ...process.env, DATABASE_URL: dbUrl! } },
+      { env: { ...process.env, DATABASE_URL: dbUrl! }, stderr: "pipe" },
     );
-    const stdout = await new Response(proc.stdout).text();
-    const stderr = await new Response(proc.stderr).text();
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
     const exit = await proc.exited;
     expect({ exit, stdout, stderr }).toMatchObject({ exit: 0 });
 
@@ -141,12 +147,27 @@ d("delete-org integration", () => {
     const userLeft = (await sql`SELECT id FROM auth_user WHERE id = ${userId}`) as Array<unknown>;
     expect(userLeft).toHaveLength(1);
 
-    // cleanup the other org we created
-    await sql`DELETE FROM organization_developer WHERE organization_id = ${otherOrgId}`;
-    await sql`DELETE FROM developers WHERE id = ${sharedDevId}`;
-    await sql`DELETE FROM organization WHERE id = ${otherOrgId}`;
-    await sql`DELETE FROM auth_user WHERE id = ${userId}`;
-
-    await sql.close();
+    } finally {
+      // Cleanup runs even when an assertion above throws, so test rows from
+      // a failed run don't pollute the next invocation. Each statement is
+      // independent and best-effort: a missing row from a partial-seed run
+      // is fine, but unexpected errors should surface — we rethrow at the end.
+      const cleanupErrors: unknown[] = [];
+      const safe = async (run: () => Promise<unknown>) => {
+        try {
+          await run();
+        } catch (err) {
+          cleanupErrors.push(err);
+        }
+      };
+      await safe(() => sql`DELETE FROM organization_developer WHERE organization_id = ${otherOrgId}`);
+      await safe(() => sql`DELETE FROM developers WHERE id = ${sharedDevId}`);
+      await safe(() => sql`DELETE FROM organization WHERE id = ${otherOrgId}`);
+      await safe(() => sql`DELETE FROM auth_user WHERE id = ${userId}`);
+      await sql.close();
+      if (cleanupErrors.length > 0) {
+        console.error("delete-org test cleanup errors:", cleanupErrors);
+      }
+    }
   }, 30_000);
 });

--- a/packages/backend/scripts/delete-org.ts
+++ b/packages/backend/scripts/delete-org.ts
@@ -91,23 +91,12 @@ function residualQueries(orgId: string) {
     { table: "claude_md_snapshots", where: `organization_id = $1`, params: [o] },
     { table: "claude_md_correlations", where: `organization_id = $1`, params: [o] },
     { table: "workflow_profiles", where: `organization_id = $1`, params: [o] },
-    // Sole-org-developer tail: developer rows that ONLY belonged to this org.
-    // After deletion, none of these should reference a developer that was a
-    // sole-org member of $orgId. This residual query is best-effort: once
-    // organization_developer is gone, we cannot recover the sole-org list, so
-    // we instead check that no orphan developer rows exist whose only purpose
-    // would have been this org. The pre-deletion plan handles this set
-    // explicitly; here we just look for orphans pointing at deleted sessions.
-    {
-      table: "sessions (orphans)",
-      where: `developer_id NOT IN (SELECT id FROM developers)`,
-      params: [],
-    },
-    {
-      table: "events (orphans)",
-      where: `session_id NOT IN (SELECT id FROM sessions)`,
-      params: [],
-    },
+    // Note: a global orphan scan for sessions/events was intentionally removed.
+    // Database-wide checks ("developer_id NOT IN (SELECT id FROM developers)")
+    // would surface unrelated noise from other orgs and cause false positives
+    // in --verify and the post-commit residual gate. The per-table org-scoped
+    // checks above already verify the target org's data is gone; sole-org
+    // developer cleanup is handled in runDeletePlan, not here.
   ];
 }
 
@@ -317,49 +306,50 @@ async function main() {
   }
 
   // Execute the plan inside a transaction. Bun.sql exposes sql.begin().
-  let counts: Counts = {};
-  let rolledBack = false;
   try {
-    await sql.begin(async (tx: SQL) => {
-      counts = await runDeletePlan(tx, args.orgId);
-      if (args.dryRun) {
-        // Force rollback by throwing a sentinel error
-        rolledBack = true;
-        throw new Error("__dry_run_rollback__");
+    let counts: Counts = {};
+    let rolledBack = false;
+    try {
+      await sql.begin(async (tx: SQL) => {
+        counts = await runDeletePlan(tx, args.orgId);
+        if (args.dryRun) {
+          // Force rollback by throwing a sentinel error
+          rolledBack = true;
+          throw new Error("__dry_run_rollback__");
+        }
+      });
+    } catch (err) {
+      if (rolledBack && (err as Error).message === "__dry_run_rollback__") {
+        // expected — swallow
+      } else {
+        throw err;
       }
-    });
-  } catch (err) {
-    if (rolledBack && (err as Error).message === "__dry_run_rollback__") {
-      // expected — swallow
-    } else {
-      throw err;
     }
-  }
 
-  console.log(
-    JSON.stringify(
-      {
-        orgId: args.orgId,
-        mode: args.dryRun ? "dry-run (rolled back)" : "committed",
-        deleted: counts,
-      },
-      null,
-      2,
-    ),
-  );
+    console.log(
+      JSON.stringify(
+        {
+          orgId: args.orgId,
+          mode: args.dryRun ? "dry-run (rolled back)" : "committed",
+          deleted: counts,
+        },
+        null,
+        2,
+      ),
+    );
 
-  if (!args.dryRun) {
-    const residual = await countResiduals(sql, args.orgId);
-    const nonzero = Object.entries(residual).filter(([, n]) => n > 0);
-    console.log("post-delete residual:", JSON.stringify(residual, null, 2));
-    if (nonzero.length > 0) {
-      console.error("RESIDUAL ROWS DETECTED — investigate:", nonzero);
-      await sql.close();
-      process.exit(1);
+    if (!args.dryRun) {
+      const residual = await countResiduals(sql, args.orgId);
+      const nonzero = Object.entries(residual).filter(([, n]) => n > 0);
+      console.log("post-delete residual:", JSON.stringify(residual, null, 2));
+      if (nonzero.length > 0) {
+        console.error("RESIDUAL ROWS DETECTED — investigate:", nonzero);
+        process.exitCode = 1;
+      }
     }
+  } finally {
+    await sql.close();
   }
-
-  await sql.close();
 }
 
 main().catch((e) => {

--- a/packages/backend/scripts/delete-org.ts
+++ b/packages/backend/scripts/delete-org.ts
@@ -1,0 +1,368 @@
+#!/usr/bin/env bun
+/**
+ * delete-org.ts — Operator kill-switch for org-scoped data ("consent revoke").
+ *
+ * USAGE
+ *   bun run packages/backend/scripts/delete-org.ts <organizationId> [--verify] [--dry-run] [--yes]
+ *
+ * MODES
+ *   --verify    Only count residual rows for the org across every org-scoped
+ *               table. Exits 0 if all counts are zero, 1 otherwise. Does not
+ *               write anything.
+ *   --dry-run   Run the full deletion plan inside a transaction, then ROLLBACK.
+ *               Prints per-table delete counts. Useful before the real run.
+ *   --yes       Skip the interactive confirmation prompt.
+ *
+ * SAFETY
+ *   - Runs every DELETE inside a single transaction. On any error, nothing is
+ *     committed.
+ *   - Sole-org developers (linked to this org and no other) have their session
+ *     tree (sessions, events, session_titles, pattern matches, alert_events,
+ *     friction_alerts, claude_md_snapshots, workflow_profiles) wiped.
+ *   - Shared developers (linked to multiple orgs) are kept; only their
+ *     organization_developer link to this org is removed via the implicit
+ *     cascade from `organization`.
+ *   - auth_user accounts are NOT touched. A user may own other orgs.
+ *   - API keys are user-scoped, not org-scoped, and are also untouched.
+ *
+ * BACKGROUND
+ *   See DEV-33 for the table-by-table cascade audit.  Many org-scoped tables
+ *   were created with `organization_id TEXT` and no FK constraint, so the
+ *   `organization` row alone does NOT cascade them. This script deletes them
+ *   explicitly.
+ */
+
+import { SQL } from "bun";
+
+type Counts = Record<string, number>;
+
+interface Args {
+  orgId: string;
+  verify: boolean;
+  dryRun: boolean;
+  yes: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional = argv.filter((a) => !a.startsWith("--"));
+  const flags = new Set(argv.filter((a) => a.startsWith("--")));
+  const orgId = positional[0];
+  if (!orgId) {
+    console.error("usage: delete-org.ts <organizationId> [--verify] [--dry-run] [--yes]");
+    process.exit(2);
+  }
+  return {
+    orgId,
+    verify: flags.has("--verify"),
+    dryRun: flags.has("--dry-run"),
+    yes: flags.has("--yes"),
+  };
+}
+
+/**
+ * Every table that may hold data scoped to an organization, with the WHERE
+ * clause used to count residuals. Some tables can be reached only by joining
+ * through sessions / developers, so the residual check uses those joins.
+ */
+function residualQueries(orgId: string) {
+  const o = orgId;
+  return [
+    // Direct org_id columns (mostly no FK — this is why we need the script)
+    { table: "organization", where: `id = $1`, params: [o] },
+    { table: "member", where: `"organizationId" = $1`, params: [o] },
+    { table: "invitation", where: `"organizationId" = $1`, params: [o] },
+    { table: "organization_developer", where: `organization_id = $1`, params: [o] },
+    { table: "organization_settings", where: `organization_id = $1`, params: [o] },
+    { table: "alert_rules", where: `organization_id = $1`, params: [o] },
+    { table: "digests", where: `organization_id = $1`, params: [o] },
+    { table: "ai_conversations", where: `organization_id = $1`, params: [o] },
+    { table: "ai_insights", where: `organization_id = $1`, params: [o] },
+    { table: "ai_reports", where: `organization_id = $1`, params: [o] },
+    { table: "ai_token_usage", where: `organization_id = $1`, params: [o] },
+    { table: "team_skills", where: `organization_id = $1`, params: [o] },
+    { table: "team_tool_topology", where: `organization_id = $1`, params: [o] },
+    { table: "team_skill_gaps", where: `organization_id = $1`, params: [o] },
+    { table: "tooling_health_snapshots", where: `organization_id = $1`, params: [o] },
+    { table: "retention_log", where: `organization_id = $1`, params: [o] },
+    { table: "data_requests", where: `organization_id = $1`, params: [o] },
+    { table: "friction_rules", where: `organization_id = $1`, params: [o] },
+    { table: "friction_alerts", where: `organization_id = $1`, params: [o] },
+    { table: "ethics_audit_log", where: `organization_id = $1`, params: [o] },
+    { table: "claude_md_snapshots", where: `organization_id = $1`, params: [o] },
+    { table: "claude_md_correlations", where: `organization_id = $1`, params: [o] },
+    { table: "workflow_profiles", where: `organization_id = $1`, params: [o] },
+    // Sole-org-developer tail: developer rows that ONLY belonged to this org.
+    // After deletion, none of these should reference a developer that was a
+    // sole-org member of $orgId. This residual query is best-effort: once
+    // organization_developer is gone, we cannot recover the sole-org list, so
+    // we instead check that no orphan developer rows exist whose only purpose
+    // would have been this org. The pre-deletion plan handles this set
+    // explicitly; here we just look for orphans pointing at deleted sessions.
+    {
+      table: "sessions (orphans)",
+      where: `developer_id NOT IN (SELECT id FROM developers)`,
+      params: [],
+    },
+    {
+      table: "events (orphans)",
+      where: `session_id NOT IN (SELECT id FROM sessions)`,
+      params: [],
+    },
+  ];
+}
+
+async function countResiduals(sql: SQL, orgId: string): Promise<Counts> {
+  const counts: Counts = {};
+  for (const q of residualQueries(orgId)) {
+    const rows = await sql.unsafe(
+      `SELECT COUNT(*)::int AS n FROM ${q.table.split(" ")[0]} WHERE ${q.where}`,
+      q.params,
+    );
+    counts[q.table] = (rows as Array<{ n: number }>)[0]?.n ?? 0;
+  }
+  return counts;
+}
+
+/**
+ * Execute the full deletion plan inside the given transaction client.
+ * Returns rows-deleted per table.
+ */
+async function runDeletePlan(tx: SQL, orgId: string): Promise<Counts> {
+  const out: Counts = {};
+  const o = orgId;
+
+  // Step 1: identify sole-org developers (linked only to this org).
+  const soleOrgDevsRows = (await tx`
+    SELECT od.developer_id
+    FROM organization_developer od
+    WHERE od.organization_id = ${o}
+      AND NOT EXISTS (
+        SELECT 1 FROM organization_developer od2
+        WHERE od2.developer_id = od.developer_id
+          AND od2.organization_id <> ${o}
+      )
+  `) as Array<{ developer_id: string }>;
+  const soleOrgDevs = soleOrgDevsRows.map((r) => r.developer_id);
+
+  // Step 2: identify session ids belonging to sole-org developers.
+  let soleOrgSessions: string[] = [];
+  if (soleOrgDevs.length > 0) {
+    const rows = (await tx`
+      SELECT id FROM sessions WHERE developer_id IN ${tx(soleOrgDevs)}
+    `) as Array<{ id: string }>;
+    soleOrgSessions = rows.map((r) => r.id);
+  }
+
+  out["_sole_org_developers"] = soleOrgDevs.length;
+  out["_sole_org_sessions"] = soleOrgSessions.length;
+
+  // Helper: run a delete and record count
+  const del = async (label: string, run: () => Promise<unknown>) => {
+    const r = (await run()) as { count?: number } | undefined;
+    out[label] = r?.count ?? 0;
+  };
+
+  // ---- Session-tree wipe (only if there are sole-org sessions) ----
+  if (soleOrgSessions.length > 0) {
+    await del(
+      "alert_events",
+      () => tx`DELETE FROM alert_events WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    await del(
+      "session_pattern_matches",
+      () => tx`DELETE FROM session_pattern_matches WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    await del(
+      "session_anti_pattern_matches",
+      () => tx`DELETE FROM session_anti_pattern_matches WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    await del(
+      "session_titles",
+      () => tx`DELETE FROM session_titles WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    await del(
+      "events",
+      () => tx`DELETE FROM events WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    // claude_md_snapshots/correlations may match by session OR by org. Cover both.
+    await del(
+      "claude_md_correlations(snapshot)",
+      () => tx`
+        DELETE FROM claude_md_correlations
+        WHERE snapshot_id IN (
+          SELECT id FROM claude_md_snapshots WHERE session_id IN ${tx(soleOrgSessions)}
+        )
+      `,
+    );
+    await del(
+      "claude_md_snapshots(session)",
+      () => tx`DELETE FROM claude_md_snapshots WHERE session_id IN ${tx(soleOrgSessions)}`,
+    );
+    await del(
+      "sessions",
+      () => tx`DELETE FROM sessions WHERE id IN ${tx(soleOrgSessions)}`,
+    );
+  }
+
+  if (soleOrgDevs.length > 0) {
+    // alert_events also has developer_id without FK — cover any rows we missed
+    await del(
+      "alert_events(dev)",
+      () => tx`DELETE FROM alert_events WHERE developer_id IN ${tx(soleOrgDevs)}`,
+    );
+    await del(
+      "friction_alerts(dev)",
+      () => tx`DELETE FROM friction_alerts WHERE developer_id IN ${tx(soleOrgDevs)}`,
+    );
+    await del(
+      "workflow_profiles(dev)",
+      () => tx`DELETE FROM workflow_profiles WHERE developer_id IN ${tx(soleOrgDevs)}`,
+    );
+    // user_developer_link cascades from developers, but be explicit.
+    await del(
+      "user_developer_link",
+      () => tx`DELETE FROM user_developer_link WHERE developer_id IN ${tx(soleOrgDevs)}`,
+    );
+    await del(
+      "developers",
+      () => tx`DELETE FROM developers WHERE id IN ${tx(soleOrgDevs)}`,
+    );
+  }
+
+  // ---- Org-scoped tables (no FK to organization) ----
+  await del("alert_rules", () => tx`DELETE FROM alert_rules WHERE organization_id = ${o}`);
+  await del("digests", () => tx`DELETE FROM digests WHERE organization_id = ${o}`);
+  // ai_messages cascade from ai_conversations, so deleting conversations is enough.
+  await del(
+    "ai_conversations",
+    () => tx`DELETE FROM ai_conversations WHERE organization_id = ${o}`,
+  );
+  await del("ai_insights", () => tx`DELETE FROM ai_insights WHERE organization_id = ${o}`);
+  await del("ai_reports", () => tx`DELETE FROM ai_reports WHERE organization_id = ${o}`);
+  await del(
+    "ai_token_usage",
+    () => tx`DELETE FROM ai_token_usage WHERE organization_id = ${o}`,
+  );
+  // team_skill_pattern_links cascades from team_skills.
+  await del("team_skills", () => tx`DELETE FROM team_skills WHERE organization_id = ${o}`);
+  await del(
+    "team_tool_topology",
+    () => tx`DELETE FROM team_tool_topology WHERE organization_id = ${o}`,
+  );
+  await del(
+    "team_skill_gaps",
+    () => tx`DELETE FROM team_skill_gaps WHERE organization_id = ${o}`,
+  );
+  await del(
+    "tooling_health_snapshots",
+    () => tx`DELETE FROM tooling_health_snapshots WHERE organization_id = ${o}`,
+  );
+  await del("retention_log", () => tx`DELETE FROM retention_log WHERE organization_id = ${o}`);
+  await del("data_requests", () => tx`DELETE FROM data_requests WHERE organization_id = ${o}`);
+  await del("friction_rules", () => tx`DELETE FROM friction_rules WHERE organization_id = ${o}`);
+  await del(
+    "friction_alerts(org)",
+    () => tx`DELETE FROM friction_alerts WHERE organization_id = ${o}`,
+  );
+  // Ethics audit log: per consent-revoke promise we delete the org's audit
+  // entries. If a future compliance review wants these retained-but-anonymized
+  // instead, change this to UPDATE ... SET organization_id = NULL.
+  await del(
+    "ethics_audit_log",
+    () => tx`DELETE FROM ethics_audit_log WHERE organization_id = ${o}`,
+  );
+  await del(
+    "claude_md_correlations(org)",
+    () => tx`DELETE FROM claude_md_correlations WHERE organization_id = ${o}`,
+  );
+  await del(
+    "claude_md_snapshots(org)",
+    () => tx`DELETE FROM claude_md_snapshots WHERE organization_id = ${o}`,
+  );
+  await del(
+    "workflow_profiles(org)",
+    () => tx`DELETE FROM workflow_profiles WHERE organization_id = ${o}`,
+  );
+
+  // ---- Finally drop the org row.  Cascades:
+  //        member, invitation, organization_developer, organization_settings ----
+  await del("organization", () => tx`DELETE FROM organization WHERE id = ${o}`);
+
+  return out;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is not set. Refusing to run.");
+    process.exit(2);
+  }
+  const sql = new SQL({ url, max: 4 });
+
+  if (args.verify) {
+    const counts = await countResiduals(sql, args.orgId);
+    const residual = Object.entries(counts).filter(([, n]) => n > 0);
+    console.log(JSON.stringify({ orgId: args.orgId, counts, residual }, null, 2));
+    await sql.close();
+    process.exit(residual.length === 0 ? 0 : 1);
+  }
+
+  if (!args.yes && !args.dryRun) {
+    console.error(
+      `About to HARD DELETE all data for organization ${args.orgId}.\n` +
+        `Run with --dry-run first, then re-run with --yes to confirm.`,
+    );
+    process.exit(2);
+  }
+
+  // Execute the plan inside a transaction. Bun.sql exposes sql.begin().
+  let counts: Counts = {};
+  let rolledBack = false;
+  try {
+    await sql.begin(async (tx: SQL) => {
+      counts = await runDeletePlan(tx, args.orgId);
+      if (args.dryRun) {
+        // Force rollback by throwing a sentinel error
+        rolledBack = true;
+        throw new Error("__dry_run_rollback__");
+      }
+    });
+  } catch (err) {
+    if (rolledBack && (err as Error).message === "__dry_run_rollback__") {
+      // expected — swallow
+    } else {
+      throw err;
+    }
+  }
+
+  console.log(
+    JSON.stringify(
+      {
+        orgId: args.orgId,
+        mode: args.dryRun ? "dry-run (rolled back)" : "committed",
+        deleted: counts,
+      },
+      null,
+      2,
+    ),
+  );
+
+  if (!args.dryRun) {
+    const residual = await countResiduals(sql, args.orgId);
+    const nonzero = Object.entries(residual).filter(([, n]) => n > 0);
+    console.log("post-delete residual:", JSON.stringify(residual, null, 2));
+    if (nonzero.length > 0) {
+      console.error("RESIDUAL ROWS DETECTED — investigate:", nonzero);
+      await sql.close();
+      process.exit(1);
+    }
+  }
+
+  await sql.close();
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Operator kill-switch for revoking a pilot org's consent. The cascade audit on [DEV-33](/DEV/issues/DEV-33) found that only ~4 of ~25 org-scoped tables actually cascade from `organization` — the rest were created with bare `organization_id TEXT` columns and no FK. A naive `DELETE FROM organization` would leave orphaned rows across ~17 tables.

This PR adds a transactional script that deletes them explicitly, in dependency order, plus a 1-page runbook and an integration test.

### What's in here

- **`packages/backend/scripts/delete-org.ts`** — single-transaction deletion with three modes:
  - `--dry-run` runs the full plan inside a transaction then ROLLBACKs (safe pre-flight)
  - `--yes` executes (interactive confirm by default)
  - `--verify` read-only residual count across every org-scoped table; non-zero exit if anything survived
- **`packages/backend/docs/operations.md`** — runbook section with the 3-command flow.
- **`packages/backend/scripts/__tests__/delete-org.test.ts`** — integration test (gated on `TEST_DATABASE_URL`) seeds an org across every org-scoped table, runs the script, asserts zero residuals.

### Safety properties

- Single `BEGIN`/`COMMIT` — partial deletion impossible.
- Sole-org developers (linked to this org and no other) get their session tree wiped (sessions, events, session_titles, pattern matches, alert_events, friction_alerts, claude_md_snapshots, workflow_profiles).
- Shared developers (linked to multiple orgs) are preserved; only the `organization_developer` row is removed.
- `auth_user` accounts and API keys are NOT touched (user-scoped, not org-scoped).
- `--verify` is the post-run audit and can be re-run anytime.

## Test plan

- [ ] On a dev box (or staging once available): `docker compose up postgres`, then `TEST_DATABASE_URL=postgres://... bun test packages/backend/scripts/__tests__/delete-org.test.ts`.
- [ ] Pick a throwaway org, run with `--dry-run` and confirm the per-table delete counts look sane.
- [ ] Run with `--yes` and confirm `committed`.
- [ ] Run with `--verify` and confirm exit 0 with all-zero counts.

## Follow-ups (filed in the [DEV-33 plan document](/DEV/issues/DEV-33#document-plan))

1. Add real `REFERENCES organization(id) ON DELETE CASCADE` FKs to the ~17 columns missing them — this script becomes belt-and-suspenders.
2. Decide `ethics_audit_log` retention policy on consent revoke (delete vs anonymize) — current script deletes; flag for legal before the first real revoke.
3. Optional: wrap the script in `DELETE /api/organizations/:id` so prod operators don't need shell access. Out of scope for pilot.

Closes [DEV-33](/DEV/issues/DEV-33).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an operations runbook documenting a multi-step org data deletion workflow with dry-run preview, transactional execution, and post-deletion verification.

* **New Features**
  * Added a command-line utility to perform org-wide deletions with --dry-run, --verify, and --yes modes and safeguards to avoid partial deletions; preserves user accounts and API keys.

* **Tests**
  * Added an integration test validating deletion behavior and cross-org relationships.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->