### PR TITLE
DEV-42: re-land DEV-24 namespace migration onto main (renumbered 033)

### DIFF
--- a/packages/backend/src/db/migrations/033_merge_apikey_developers_into_canonical.sql
+++ b/packages/backend/src/db/migrations/033_merge_apikey_developers_into_canonical.sql
@@ -1,0 +1,127 @@
+-- DEV-24: collapse the legacy `apikey-<authUserId>` developer namespace into
+-- the canonical SHA256(email) namespace produced by the plugin and (post
+-- DEV-24) by `/api/events/hook`.
+--
+-- Highest-risk piece of Bet A — must be reviewed against a staging-data
+-- dump before running in prod (per DEV-11 constraint).
+--
+-- Idempotent: when there are no `apikey-%` rows left in `developers`, the
+-- DO block iterates zero times and the migration is a no-op. Safe to
+-- re-run.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+DO $$
+DECLARE
+  rec RECORD;
+  canonical_id TEXT;
+  canonical_email TEXT;
+  canonical_name TEXT;
+  apikey_count INT := 0;
+  merged_count INT := 0;
+  skipped_count INT := 0;
+BEGIN
+  -- Snapshot the work set up front so concurrent inserts during the migration
+  -- (extremely unlikely on staging/prod since this runs at process start) do
+  -- not cause us to chase a moving target.
+  CREATE TEMP TABLE _dev24_pending ON COMMIT DROP AS
+    SELECT id AS old_dev_id,
+           SUBSTRING(id FROM 8) AS auth_user_id  -- strip 'apikey-' (7 chars)
+    FROM developers
+    WHERE id LIKE 'apikey-%';
+
+  SELECT COUNT(*) INTO apikey_count FROM _dev24_pending;
+  IF apikey_count = 0 THEN
+    RAISE NOTICE '[028] no apikey-* developer rows — nothing to do';
+    RETURN;
+  END IF;
+
+  RAISE NOTICE '[028] merging % apikey-* developer rows into SHA256(email) canonical rows', apikey_count;
+
+  FOR rec IN SELECT * FROM _dev24_pending LOOP
+    SELECT email, name INTO canonical_email, canonical_name
+    FROM auth_user
+    WHERE id = rec.auth_user_id;
+
+    IF canonical_email IS NULL OR canonical_email = '' THEN
+      -- The auth_user is gone (account deletion) and we cannot derive a
+      -- canonical id. Leave the row so historical events still attribute
+      -- somewhere; a follow-up cleanup can decide whether to soft-delete.
+      RAISE NOTICE '[028] skip %: no auth_user.email found for %', rec.old_dev_id, rec.auth_user_id;
+      skipped_count := skipped_count + 1;
+      CONTINUE;
+    END IF;
+
+    canonical_id := encode(digest(lower(btrim(canonical_email)), 'sha256'), 'hex');
+
+    -- Ensure the canonical developers row exists. Preserve the earliest
+    -- first_seen (the apikey row may pre-date the plugin row) so historical
+    -- timelines stay correct.
+    INSERT INTO developers (id, name, email, first_seen, last_seen)
+    SELECT canonical_id,
+           COALESCE(NULLIF(canonical_name, ''), 'Developer'),
+           canonical_email,
+           d.first_seen,
+           d.last_seen
+    FROM developers d
+    WHERE d.id = rec.old_dev_id
+    ON CONFLICT (id) DO UPDATE SET
+      first_seen = LEAST(developers.first_seen, EXCLUDED.first_seen),
+      last_seen  = GREATEST(developers.last_seen, EXCLUDED.last_seen),
+      email      = CASE WHEN developers.email = '' OR developers.email IS NULL
+                        THEN EXCLUDED.email ELSE developers.email END,
+      name       = CASE WHEN developers.name = '' OR developers.name = 'API Key User' OR developers.name IS NULL
+                        THEN EXCLUDED.name ELSE developers.name END;
+
+    -- Repoint sessions (FK NO ACTION — must move before we delete the apikey row).
+    UPDATE sessions
+       SET developer_id = canonical_id
+     WHERE developer_id = rec.old_dev_id;
+
+    -- Repoint denormalized developer_id columns (no FK; preserve attribution).
+    UPDATE alert_events         SET developer_id = canonical_id WHERE developer_id = rec.old_dev_id;
+    UPDATE friction_alerts      SET developer_id = canonical_id WHERE developer_id = rec.old_dev_id;
+    UPDATE claude_md_snapshots  SET developer_id = canonical_id WHERE developer_id = rec.old_dev_id;
+    UPDATE privacy_requests     SET developer_id = canonical_id WHERE developer_id = rec.old_dev_id;
+
+    -- workflow_profiles has UNIQUE(developer_id, period_start, period_end).
+    -- If the canonical row already has a profile for the same period (very
+    -- rare in practice but possible for users who used both pathways in the
+    -- same week), keep the canonical one and drop the apikey one.
+    UPDATE workflow_profiles wp_old
+       SET developer_id = canonical_id
+     WHERE wp_old.developer_id = rec.old_dev_id
+       AND NOT EXISTS (
+         SELECT 1 FROM workflow_profiles wp_new
+          WHERE wp_new.developer_id = canonical_id
+            AND wp_new.period_start  = wp_old.period_start
+            AND wp_new.period_end    = wp_old.period_end
+       );
+    DELETE FROM workflow_profiles WHERE developer_id = rec.old_dev_id;
+
+    -- organization_developer: PK (organization_id, developer_id). Carry over
+    -- any org links and drop the apikey-keyed rows.
+    INSERT INTO organization_developer (organization_id, developer_id)
+    SELECT organization_id, canonical_id
+      FROM organization_developer
+     WHERE developer_id = rec.old_dev_id
+    ON CONFLICT DO NOTHING;
+    DELETE FROM organization_developer WHERE developer_id = rec.old_dev_id;
+
+    -- user_developer_link: post-024 has UNIQUE(developer_id). Insert the
+    -- canonical link if no other user already claims canonical_id; then
+    -- drop the apikey-keyed row.
+    INSERT INTO user_developer_link (auth_user_id, developer_id)
+    VALUES (rec.auth_user_id, canonical_id)
+    ON CONFLICT (developer_id) DO NOTHING;
+    DELETE FROM user_developer_link WHERE developer_id = rec.old_dev_id;
+
+    -- Finally, remove the now-orphan apikey developer row.
+    DELETE FROM developers WHERE id = rec.old_dev_id;
+    merged_count := merged_count + 1;
+  END LOOP;
+
+  RAISE NOTICE '[028] merge complete: merged=%, skipped=%, total=%',
+    merged_count, skipped_count, apikey_count;
+END
+$$;

--- a/packages/backend/src/db/migrations/033_merge_apikey_developers_into_canonical.sql
+++ b/packages/backend/src/db/migrations/033_merge_apikey_developers_into_canonical.sql
@@ -32,11 +32,11 @@ BEGIN
 
   SELECT COUNT(*) INTO apikey_count FROM _dev24_pending;
   IF apikey_count = 0 THEN
-    RAISE NOTICE '[028] no apikey-* developer rows — nothing to do';
+    RAISE NOTICE '[033] no apikey-* developer rows — nothing to do';
     RETURN;
   END IF;
 
-  RAISE NOTICE '[028] merging % apikey-* developer rows into SHA256(email) canonical rows', apikey_count;
+  RAISE NOTICE '[033] merging % apikey-* developer rows into SHA256(email) canonical rows', apikey_count;
 
   FOR rec IN SELECT * FROM _dev24_pending LOOP
     SELECT email, name INTO canonical_email, canonical_name

--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -126,7 +126,11 @@ function validEvent(overrides: Record<string, unknown> = {}) {
  */
 function buildApp(
   sql: any,
-  opts: { apiKeyUserId?: string; orgDeveloperIds?: string[] } = {},
+  opts: {
+    apiKeyUserId?: string;
+    orgDeveloperIds?: string[];
+    user?: { id?: string; name?: string; email?: string };
+  } = {},
 ) {
   const app = new Hono();
 
@@ -136,6 +140,9 @@ function buildApp(
     }
     if (opts.orgDeveloperIds !== undefined) {
       c.set("orgDeveloperIds" as never, opts.orgDeveloperIds as never);
+    }
+    if (opts.user !== undefined) {
+      c.set("user" as never, opts.user as never);
     }
     await next();
   });
@@ -740,6 +747,95 @@ describe("POST /events", () => {
     const orgIds = mockBroadcastToOrg.mock.calls.map((c: any) => c[0]);
     expect(orgIds).toContain("org-1");
     expect(orgIds).toContain("org-2");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /hook -- Claude Code HTTP hook ingestion (DEV-24: SHA256(email) namespace)
+// ---------------------------------------------------------------------------
+
+describe("POST /events/hook", () => {
+  // sha256("alice@example.com") — must match computeDeveloperId behavior.
+  const ALICE_DEV_ID =
+    "ff8d9819fc0e12bf0d24892e45987e249a28dce836a85cad60e28eaaa8c6d976";
+
+  beforeEach(() => {
+    mockUpsertDeveloper.mockReset();
+    mockUpsertDeveloper.mockImplementation(() => Promise.resolve());
+    mockInsertEvent.mockReset();
+    mockInsertEvent.mockImplementation(() => Promise.resolve({ stored: true }));
+    mockCreateSession.mockReset();
+    mockCreateSession.mockImplementation(() => Promise.resolve());
+    mockAutoLinkDeveloperToOrg.mockReset();
+    mockAutoLinkDeveloperToOrg.mockImplementation(() => Promise.resolve());
+  });
+
+  test("derives developerId from SHA256(authUser.email), not apikey-<userId>", async () => {
+    const sql = makeMockSql();
+    const app = buildApp(sql, {
+      apiKeyUserId: "user-owner-1",
+      user: { id: "user-owner-1", name: "Alice", email: "alice@example.com" },
+    });
+
+    const res = await app.request("/hook?event=notification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: "sess-hook-1",
+        cwd: "/home/alice/proj",
+        tool_name: "Bash",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockUpsertDeveloper).toHaveBeenCalledTimes(1);
+    expect(mockUpsertDeveloper).toHaveBeenCalledWith(
+      sql,
+      ALICE_DEV_ID,
+      "Alice",
+      "alice@example.com",
+    );
+    expect(mockAutoLinkDeveloperToOrg).toHaveBeenCalledWith(
+      sql,
+      "user-owner-1",
+      ALICE_DEV_ID,
+    );
+    // The inserted event must carry the canonical developerId.
+    const insertedEvent = (mockInsertEvent.mock.calls[0] as any[])[1];
+    expect(insertedEvent.developerId).toBe(ALICE_DEV_ID);
+    expect(insertedEvent.developerEmail).toBe("alice@example.com");
+    expect(insertedEvent.developerId.startsWith("apikey-")).toBe(false);
+  });
+
+  test("rejects when API key auth is missing", async () => {
+    const sql = makeMockSql();
+    const app = buildApp(sql); // no apiKeyUserId, no user
+
+    const res = await app.request("/hook?event=notification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: "s", cwd: "/x" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockInsertEvent).not.toHaveBeenCalled();
+  });
+
+  test("rejects when apiKeyUserId is set but auth user has no email", async () => {
+    const sql = makeMockSql();
+    const app = buildApp(sql, {
+      apiKeyUserId: "user-owner-1",
+      user: { id: "user-owner-1", name: "Alice" }, // missing email
+    });
+
+    const res = await app.request("/hook?event=notification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: "s", cwd: "/x" }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockInsertEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -17,7 +17,7 @@ import {
   finalizeTokenSegment,
 } from "../db";
 import { broadcastToOrg } from "../ws/handler";
-import { autoLinkDeveloperToOrg, autoLinkUserToDeveloper } from "../services/developerLink";
+import { autoLinkDeveloperToOrg, autoLinkUserToDeveloper, computeDeveloperId } from "../services/developerLink";
 import { stripSensitivePayload } from "../utils/stripSensitiveFields";
 import { logEthicsEvent } from "../utils/ethicsAudit";
 import { evaluateFriction, cleanupFrictionSession } from "../services/frictionDetector";
@@ -458,7 +458,8 @@ export function eventsRoutes(sql: SQL) {
 
     // Derive developer identity from API key owner
     const apiKeyUserId = c.get("apiKeyUserId" as never) as string | undefined;
-    if (!apiKeyUserId) {
+    const authUser = c.get("user" as never) as { id?: string; name?: string; email?: string } | undefined;
+    if (!apiKeyUserId || !authUser?.email) {
       return c.json({ error: "HTTP hooks require API key authentication" }, 401);
     }
 
@@ -472,9 +473,11 @@ export function eventsRoutes(sql: SQL) {
     const cwd = String(body.cwd ?? "");
     const projectName = cwd ? cwd.split("/").pop() ?? "unknown" : "unknown";
 
-    // Use API key user ID directly as developer identity
-    const developerId = `apikey-${apiKeyUserId}`;
-    const developerName = "API Key User";
+    // Single developer-id namespace (DEV-24): synthesize SHA256(email) from
+    // the API-key owner's account email. Same derivation as the plugin.
+    const developerEmail = authUser.email;
+    const developerId = computeDeveloperId(developerEmail);
+    const developerName = authUser.name && authUser.name.length > 0 ? authUser.name : "Developer";
 
     // Build the normalized event
     const event: DevscopeEvent = {
@@ -483,7 +486,7 @@ export function eventsRoutes(sql: SQL) {
       sessionId,
       developerId,
       developerName,
-      developerEmail: "",
+      developerEmail,
       projectPath: cwd,
       projectName,
       eventType: eventType as any,
@@ -491,9 +494,11 @@ export function eventsRoutes(sql: SQL) {
     };
 
     // Upsert developer
-    await upsertDeveloper(sql, event.developerId, event.developerName, "");
+    await upsertDeveloper(sql, event.developerId, event.developerName, event.developerEmail ?? "");
     autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
       .catch((err) => console.error("[events/hook] autoLinkDeveloperToOrg failed:", err));
+    autoLinkUserToDeveloper(sql, apiKeyUserId, event.developerId)
+      .catch((err) => console.error("[events/hook] autoLinkUserToDeveloper failed:", err));
 
     // Ensure session exists and is active (mirrors main POST / handler behavior)
     const [existingSession] = await sql`SELECT status FROM sessions WHERE id = ${event.sessionId}`;


### PR DESCRIPTION
## Why this PR exists

PR #38 was merged into the now-defunct `feat/dev-11-idempotent-insert` stacked base, not main, so the DEV-24 namespace-merge change never actually landed. DEV-42 tracks re-landing it.

This PR re-applies the **byte-identical** original DEV-24 commit (`e178c79`) on top of current main:

- The only delta is the migration filename: `028_…` collides with main's `028_tool_subcommand.sql`, so renumber to `033_merge_apikey_developers_into_canonical.sql`.
- SQL body unchanged — NOTICE strings still log `[028]` (cosmetic; kept verbatim so the diff vs originally-reviewed PR #38 content is trivially auditable).

## What changes

Collapses the legacy `apikey-<authUserId>` developer namespace into the canonical `SHA256(email)` namespace so we have **exactly one `developers` row per real human**.

- **Hook handler** (`packages/backend/src/routes/events.ts`): `/api/events/hook` now derives `developerId = computeDeveloperId(authUser.email)` — same SHA256(email) derivation the Bash plugin uses — instead of `apikey-<authUserId>`. Also auto-links the canonical developer row back to its auth user.
- **Migration `033_merge_apikey_developers_into_canonical.sql`**: atomic `DO` block. For each `apikey-%` developer:
  1. Compute canonical id from `auth_user.email`.
  2. Ensure canonical `developers` row exists, preserving the earliest `first_seen` and the canonical email.
  3. Repoint `sessions`, `alert_events`, `friction_alerts`, `claude_md_snapshots`, `privacy_requests`, `workflow_profiles`, `organization_developer`, and `user_developer_link` to the canonical id.
  4. Delete the apikey row.
- **Idempotent**: subsequent runs are a no-op once `apikey-%` rows are gone.
- **Tests**: 3 new `POST /events/hook` tests assert canonical id derivation, missing-auth rejection, and missing-email rejection.

## Verification on this branch

\`\`\`
$ bun test src/routes/__tests__/events.test.ts
 39 pass
 0 fail
\`\`\`

## Required dry-run before merge (Lucas)

Carried over verbatim from PR #38. The DEV-11 ticket constraint mandates that this migration be reviewed against a staging-data dump before prod. With the staging gate (DEV-19) deferred, the agreed substitute is a `pg_dump` of prod restored to a throwaway local Postgres.

**Checklist for Lucas:**

- [ ] `pg_dump` prod → restore to a throwaway local Postgres.
- [ ] Capture row counts **before** the migration for: `developers` (total + `id LIKE 'apikey-%'` count), `sessions`, `alert_events`, `friction_alerts`, `claude_md_snapshots`, `privacy_requests`, `workflow_profiles`, `organization_developer`, `user_developer_link`.
- [ ] Apply migration 033.
- [ ] Capture row counts **after**. Verify:
  - `developers WHERE id LIKE 'apikey-%'` → **0**.
  - Total `developers` count = (before total) − (before `apikey-%` count) − any apikey rows that merged into pre-existing canonical rows.
  - Dependent-table totals are **unchanged** (rows were repointed, not deleted).
  - For at least one merged developer: confirm exactly one `developers` row remains for that human's email, and their session/event history is reachable through the canonical id.
- [ ] **Run migration a second time** — confirm it's a no-op (idempotency).
- [ ] Sign off in this PR before merge.

## Risk

**High** — touches developer identity for every existing user and remaps session/event history. The migration is wrapped in a `DO` block so it is per-statement atomic; if any FK update fails, the whole block rolls back.

## References

- DEV-42 wrap-up issue: tracking
- Original PR (merged into wrong base): #38
- DEV-11 base (already on main): #37 (`0b5c4d7`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved developer identification and tracking accuracy by consolidating duplicate developer records and standardizing how developers are identified in the system, ensuring consistent and reliable developer attribution across all platform features.

* **Chores**
  * Database updates to align developer record management with standardized identification approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->