### PR TITLE
DEV-44: weekly-buyer persona prompt branch in reportWorkflow.ts

### DIFF
--- a/packages/backend/src/ai/workflows/__tests__/reportWorkflow.test.ts
+++ b/packages/backend/src/ai/workflows/__tests__/reportWorkflow.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildWeeklyBuyerOutlinePrompt,
+  buildWeeklyBuyerWritePrompt,
+} from "../reportWorkflow";
+
+// Synthetic team-aggregate input. Intentionally contains no developer names,
+// emails, or hashes — the test asserts the rendered prompt template carries
+// none of those tokens either.
+const SYNTHETIC_TEAM_DATA = {
+  periodComparison: {
+    current: { sessions: 42, events: 1280 },
+    previous: { sessions: 30, events: 950 },
+    change: { sessions: 0.4, events: 0.347 },
+  },
+  teamVelocity: { sessionsPerDay: 6, completionRate: 0.91 },
+  sessionsNeedingAttention: 3,
+  teamActivity: { totalEvents: 1280, totalSessions: 42 },
+  projects: [
+    { name: "core", sessions: 15 },
+    { name: "dashboard", sessions: 12 },
+  ],
+  toolUsage: [
+    { tool: "Bash", count: 300 },
+    { tool: "Read", count: 220 },
+  ],
+  concreteToolDetails: {
+    bash: { git: 120, npm: 45 },
+    read: { "package.json": 25 },
+  },
+  sessionSummary: { totalSessions: 42, completedSessions: 38 },
+  failureClusters: [{ tool: "Bash", failures: 12, pattern: "git push rejected" }],
+  effectivePatterns: [],
+  antiPatternSummary: {},
+};
+
+const EMAIL_RE = /[\w.+-]+@[\w-]+\.[\w.-]+/;
+// Match any 32+ contiguous hex chars — covers MD5, SHA1, SHA256, and the
+// developer-id hashes the plugin produces.
+const HEX_TOKEN_RE = /\b[a-f0-9]{32,}\b/i;
+
+describe("weekly-buyer prompt template", () => {
+  test("outline prompt contains no developer-identifying tokens", () => {
+    const prompt = buildWeeklyBuyerOutlinePrompt({
+      reportType: "weekly",
+      title: "Weekly Team Narrative",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    expect(prompt).not.toMatch(EMAIL_RE);
+    expect(prompt).not.toMatch(HEX_TOKEN_RE);
+  });
+
+  test("write prompt contains no developer-identifying tokens", () => {
+    const prompt = buildWeeklyBuyerWritePrompt({
+      reportType: "weekly",
+      title: "Weekly Team Narrative",
+      outline: "1. Week summary\n2. What worked\n3. What didn't",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    expect(prompt).not.toMatch(EMAIL_RE);
+    expect(prompt).not.toMatch(HEX_TOKEN_RE);
+  });
+
+  test("both prompts forbid individual-developer language", () => {
+    const outline = buildWeeklyBuyerOutlinePrompt({
+      reportType: "weekly",
+      title: "x",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    const write = buildWeeklyBuyerWritePrompt({
+      reportType: "weekly",
+      title: "x",
+      outline: "",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    for (const prompt of [outline, write]) {
+      expect(prompt).toContain("TEAM-AGGREGATE ONLY");
+      // Explicit ban list must call out names, emails, and hashes by name.
+      expect(prompt.toLowerCase()).toMatch(/\bnames\b/);
+      expect(prompt.toLowerCase()).toMatch(/\bemails\b/);
+      expect(prompt.toLowerCase()).toMatch(/\bhashes\b/);
+    }
+  });
+
+  test("prompts establish Friday-narrative voice", () => {
+    const outline = buildWeeklyBuyerOutlinePrompt({
+      reportType: "weekly",
+      title: "x",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    const write = buildWeeklyBuyerWritePrompt({
+      reportType: "weekly",
+      title: "x",
+      outline: "",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    for (const prompt of [outline, write]) {
+      expect(prompt.toLowerCase()).toContain("friday-narrative");
+      expect(prompt.toLowerCase()).toContain("what worked");
+      expect(prompt.toLowerCase()).toContain("what didn't");
+      expect(prompt.toLowerCase()).toContain("got stuck");
+    }
+  });
+
+  test("write prompt reserves a documentation-gaps slot for the doc-gap pipeline", () => {
+    // The doc-gap subsection is the integration point for the sibling DEV-48
+    // (#12) child issue — it fills the `docGaps` data slot and the prompt
+    // renders it. Until that lands, the prompt instructs the LLM to emit a
+    // single-line placeholder rather than fabricate gaps.
+    const prompt = buildWeeklyBuyerWritePrompt({
+      reportType: "weekly",
+      title: "x",
+      outline: "",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    expect(prompt).toContain("Documentation gaps");
+    expect(prompt).toContain("docGaps");
+    expect(prompt).toContain("Doc gap data unavailable for this period.");
+  });
+
+  test("write prompt suppresses internal-only sections", () => {
+    const prompt = buildWeeklyBuyerWritePrompt({
+      reportType: "weekly",
+      title: "x",
+      outline: "",
+      data: SYNTHETIC_TEAM_DATA,
+    });
+    // The buyer artifact must not carry the internal "Improve Your Claude
+    // Code Setup" / "Action Items" / "Claude Code Skills" sections that the
+    // team-lead and developer personas produce.
+    expect(prompt).toMatch(
+      /Do NOT include "Action Items", "Improve Your Claude Code Setup", or "Claude Code Skills"/
+    );
+  });
+});

--- a/packages/backend/src/ai/workflows/reportWorkflow.ts
+++ b/packages/backend/src/ai/workflows/reportWorkflow.ts
@@ -36,6 +36,88 @@ const ReportState = Annotation.Root({
 
 type ReportStateType = typeof ReportState.State;
 
+/**
+ * Persona key for the Friday-narrative weekly team report we hand to a design
+ * partner. The branch is intentionally additive — it does not touch the
+ * `team-lead` / `developer` paths. See parent task DEV-39.
+ */
+export const WEEKLY_BUYER_PERSONA = "weekly-buyer" as const;
+
+/**
+ * Build the outline-generation prompt for the `weekly-buyer` persona.
+ *
+ * Exposed as a pure helper so the snapshot test can assert the rendered
+ * template carries zero developer-identifying tokens (names, emails, hashes)
+ * without actually calling the LLM.
+ */
+export function buildWeeklyBuyerOutlinePrompt(args: {
+  reportType: ReportType;
+  title: string;
+  data: Record<string, unknown>;
+}): string {
+  const dataStr = JSON.stringify(args.data, null, 2).slice(0, 25_000);
+
+  return `You are drafting the weekly Friday-narrative team report for DevScope.
+The reader is an external design partner — buyer-legible, not internal engineering jargon.
+
+Report type: ${args.reportType}
+Title: ${args.title}
+
+Voice & framing:
+- Friday-narrative: "this week the team worked on X. What worked: Y. What didn't: Z. Where they got stuck: W. Versus last week, the shift was V."
+- TEAM-AGGREGATE ONLY. Never mention individual developers — no names, no emails, no SHA hashes, no "Developer A/B", no "this developer", no per-person counts, no rankings or comparisons across people.
+- Concise and buyer-legible. Cut DevScope-internal jargon.
+
+Outline a ~500-word narrative with these sections, in order:
+1. Week summary (one short paragraph framing the week at a team level)
+2. What worked (up to 3 bullets, team-level only)
+3. What didn't (up to 3 bullets, team-level only)
+4. Where the team got stuck (failure clusters, project blockers — attribute to tools, projects, or sessions, never to individuals)
+5. Documentation gaps (recurring missing project context where Claude Code lacked knowledge — sourced from the \`docGaps\` field on the data when present; if absent or empty, say "Doc gap data unavailable for this period." — do not fabricate gaps)
+6. Week-over-week (use \`periodComparison\`; describe direction and magnitude in plain language)
+
+Data:
+${dataStr}
+
+Return a structured outline with the sections above. Keep it tight.`;
+}
+
+/**
+ * Build the report-writing prompt for the `weekly-buyer` persona.
+ *
+ * Like the outline helper, exported so the snapshot test can validate the
+ * rendered template against the team-aggregate guardrail without invoking
+ * the LLM.
+ */
+export function buildWeeklyBuyerWritePrompt(args: {
+  reportType: ReportType;
+  title: string;
+  outline: string;
+  data: Record<string, unknown>;
+}): string {
+  const dataStr = JSON.stringify(args.data, null, 2).slice(0, 25_000);
+
+  return `Write the weekly Friday-narrative team report in Markdown. The audience is an external design partner.
+
+Report type: ${args.reportType}
+Title: ${args.title}
+
+Outline:
+${args.outline}
+
+Data:
+${dataStr}
+
+Requirements:
+- Voice: Friday-narrative — "this week the team…", "what worked", "what didn't", "where they got stuck", "versus last week".
+- TEAM-AGGREGATE ONLY: never reference individuals. Do not include names, emails, SHA hashes, "Developer A/B", "this developer", per-person counts, or per-developer rankings or comparisons.
+- Use specific numbers and percentages from the provided data ONLY. If a figure is not in the data, say "insufficient data" — do not estimate or invent.
+- Sections, in order: "Week summary", "What worked", "What didn't", "Where the team got stuck", "Documentation gaps", "Week-over-week".
+- Documentation gaps subsection: list recurring missing project context where Claude Code lacked knowledge, sourced from the \`docGaps\` field on the data if present. If \`docGaps\` is missing or empty, write exactly: "Doc gap data unavailable for this period." — do not fabricate gaps.
+- Length: 400–700 words. Concise, buyer-legible, no DevScope-internal jargon, no instructions to the team — this is an artifact for an external reader.
+- Do NOT include "Action Items", "Improve Your Claude Code Setup", or "Claude Code Skills" sections — those are for internal personas only.`;
+}
+
 function getDaysForType(reportType: ReportType): number {
   switch (reportType) {
     case "daily":
@@ -109,6 +191,35 @@ async function gatherReportData(
 async function generateOutline(
   state: ReportStateType
 ): Promise<Partial<ReportStateType>> {
+  // Additive branch for the weekly Friday-narrative buyer report. The standard
+  // path below is untouched.
+  if (state.persona === WEEKLY_BUYER_PERSONA) {
+    const response = await callGemini(
+      [
+        {
+          role: "user",
+          parts: [
+            {
+              text: buildWeeklyBuyerOutlinePrompt({
+                reportType: state.reportType,
+                title: state.title,
+                data: state.data,
+              }),
+            },
+          ],
+        },
+      ],
+      undefined,
+      { temperature: TEMPERATURE.report }
+    );
+
+    return {
+      outline: response.text,
+      inputTokens: state.inputTokens + response.inputTokens,
+      outputTokens: state.outputTokens + response.outputTokens,
+    };
+  }
+
   const dataStr = JSON.stringify(state.data, null, 2).slice(0, 25_000);
 
   const personaGuidance = state.persona
@@ -159,6 +270,42 @@ async function writeReport(
   state: ReportStateType,
   sql: SQL
 ): Promise<Partial<ReportStateType>> {
+  // Additive branch for the weekly Friday-narrative buyer report. The standard
+  // path below is untouched.
+  if (state.persona === WEEKLY_BUYER_PERSONA) {
+    const response = await callGemini(
+      [
+        {
+          role: "user",
+          parts: [
+            {
+              text: buildWeeklyBuyerWritePrompt({
+                reportType: state.reportType,
+                title: state.title,
+                outline: state.outline,
+                data: state.data,
+              }),
+            },
+          ],
+        },
+      ],
+      undefined,
+      { temperature: TEMPERATURE.report, maxOutputTokens: 4096 }
+    );
+
+    await updateReport(sql, state.reportId, {
+      content_markdown: response.text,
+      data_context: state.data,
+      status: "completed",
+    });
+
+    return {
+      content: response.text,
+      inputTokens: state.inputTokens + response.inputTokens,
+      outputTokens: state.outputTokens + response.outputTokens,
+    };
+  }
+
   const dataStr = JSON.stringify(state.data, null, 2).slice(0, 25_000);
 
   const personaRequirements = state.persona


### PR DESCRIPTION
## Summary

Adds the `weekly-buyer` persona prompt branch in `packages/backend/src/ai/workflows/reportWorkflow.ts`. This is implementation 2/6 of #14 (Friday-narrative weekly team report we hand to a design partner).

- Additive: `team-lead` and `developer` paths are untouched. `weekly-buyer` takes early-return branches in both `generateOutline` and `writeReport` that call exported pure prompt builders.
- Reuses `getPeriodComparison` and the existing aggregation helpers — no new data shapes, no new event types, no new workflow scaffolding.
- Reserves a Documentation Gaps subsection slot for the doc-gap pipeline (DEV-48 / #12) via the `docGaps` data field, with a fixed placeholder string when absent so the LLM never fabricates gaps.
- Suppresses internal-only sections (Action Items, Improve Your Claude Code Setup, Claude Code Skills) that are inappropriate for an external-buyer artifact.

## Acceptance per [DEV-44](https://github.com/DowLucas/devscope/issues) / [DEV-37#document-plan](https://example.invalid)

- New persona produces a non-empty narrative end-to-end on a synthetic team-aggregate input (the prompt is wired into the existing graph; the LLM call uses the same `callGemini` plumbing as the other personas).
- Snapshot test asserts the prompt template contains zero developer-identifying tokens (emails, 32+ hex hashes covering MD5/SHA1/SHA256/developer-id) and that the prompt explicitly forbids names/emails/hashes.
- Existing personas unchanged — diff is purely additive (early-return branches, no edits to existing code paths' output).

## Test plan

- [x] `bun test src/ai/workflows/__tests__/reportWorkflow.test.ts` — 6 pass / 0 fail (24 expectations)
- [x] `tsc --noEmit` — no new errors in `reportWorkflow.ts` or the new test file (pre-existing errors elsewhere unrelated)
- [ ] End-to-end smoke once DEV-46 (#14 cron) lands and wires the persona to the weekly job

🤖 Generated with [Claude Code](https://claude.com/claude-code)