### PR TITLE
DEV-43: ai_reports.organization_id required + weekly-cron dedup

### DIFF
--- a/packages/backend/src/ai/workflows/reportWorkflow.ts
+++ b/packages/backend/src/ai/workflows/reportWorkflow.ts
@@ -26,6 +26,7 @@ const ReportState = Annotation.Root({
   periodEnd: Annotation<string | null>,
   persona: Annotation<string | null>,
   developerIds: Annotation<string[] | undefined>,
+  orgId: Annotation<string>,
   data: Annotation<Record<string, unknown>>,
   outline: Annotation<string>,
   content: Annotation<string>,
@@ -79,12 +80,15 @@ async function gatherReportData(
     getAntiPatternStats(sql, days),
   ]);
 
-  // Create the report record
+  // Create the report record. orgId is required (DEV-43): every report row
+  // must be tenant-scoped at the DB layer to support the weekly-cron dedup
+  // index and to prevent cross-org reads.
   const report = await createReport(sql, {
     report_type: state.reportType,
     title: state.title,
     period_start: state.periodStart ?? undefined,
     period_end: state.periodEnd ?? undefined,
+    orgId: state.orgId,
   });
 
   return {
@@ -253,6 +257,7 @@ export function createReportWorkflow(sql: SQL) {
 export async function runReportWorkflow(
   sql: SQL,
   reportType: ReportType,
+  orgId: string,
   title?: string,
   periodStart?: string,
   periodEnd?: string,
@@ -272,6 +277,7 @@ export async function runReportWorkflow(
     periodEnd: periodEnd ?? null,
     persona: persona ?? null,
     developerIds,
+    orgId,
     data: {},
     outline: "",
     content: "",

--- a/packages/backend/src/ai/workflows/sessionFeedbackWorkflow.ts
+++ b/packages/backend/src/ai/workflows/sessionFeedbackWorkflow.ts
@@ -14,6 +14,7 @@ const FeedbackState = Annotation.Root({
   privacyMode: Annotation<string | null>,
   isSelfView: Annotation<boolean>,
   includeContent: Annotation<boolean>,
+  orgId: Annotation<string>,
   data: Annotation<Record<string, unknown>>,
   content: Annotation<string>,
   reportId: Annotation<string>,
@@ -44,12 +45,14 @@ async function generateFeedback(
   state: FeedbackStateType,
   sql: SQL
 ): Promise<Partial<FeedbackStateType>> {
-  // Create the report record first
+  // Create the report record first. orgId is required at the DB layer (DEV-43);
+  // routes resolve it from the active org session before invoking this workflow.
   const report = await createReport(sql, {
     report_type: "session",
     title: `Session Debrief — ${new Date().toLocaleDateString()}`,
     period_start: undefined,
     period_end: undefined,
+    orgId: state.orgId,
   });
 
   if (!state.data || Object.keys(state.data).length === 0) {
@@ -200,7 +203,8 @@ export async function runSessionFeedbackWorkflow(
   sql: SQL,
   sessionId: string,
   privacyMode: string | null,
-  isSelfView: boolean
+  isSelfView: boolean,
+  orgId: string
 ): Promise<AiReport> {
   const app = createSessionFeedbackWorkflow(sql);
 
@@ -209,6 +213,7 @@ export async function runSessionFeedbackWorkflow(
     privacyMode,
     isSelfView,
     includeContent: false,
+    orgId,
     data: {},
     content: "",
     reportId: "",

--- a/packages/backend/src/db/__tests__/aiQueries.test.ts
+++ b/packages/backend/src/db/__tests__/aiQueries.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Integration tests for ai_reports org-scoped query path (DEV-43).
+ *
+ * Gated on TEST_DATABASE_URL — the unit suite has no live DB. To run:
+ *
+ *   TEST_DATABASE_URL=postgres://devscope:devscope@localhost:5432/devscope_test \
+ *     bun test packages/backend/src/db/__tests__/aiQueries.test.ts
+ *
+ * If the env var is unset the suite is skipped, mirroring delete-org.test.ts.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+import { initializeDatabase } from "../schema";
+import {
+  createReport,
+  createReportIfAbsent,
+  getReports,
+  getReportsForOrg,
+} from "../aiQueries";
+
+const dbUrl = process.env.TEST_DATABASE_URL;
+const d = dbUrl ? describe : describe.skip;
+
+d("aiQueries — org-scoped report path (DEV-43)", () => {
+  // Lazily initialised so describe.skip doesn't try to connect.
+  let sqlPromise: ReturnType<typeof initializeDatabase> | null = null;
+  const getSql = () => (sqlPromise ??= initializeDatabase(dbUrl!));
+
+  const orgA = `t-org-a-${crypto.randomUUID()}`;
+  const orgB = `t-org-b-${crypto.randomUUID()}`;
+
+  afterAll(async () => {
+    if (!sqlPromise) return;
+    const sql = await sqlPromise;
+    await sql`DELETE FROM ai_reports WHERE organization_id IN (${orgA}, ${orgB})`;
+    await sql`DELETE FROM organization WHERE id IN (${orgA}, ${orgB})`;
+  });
+
+  test("seeds two orgs", async () => {
+    const sql = await getSql();
+    await sql`INSERT INTO organization (id, name, slug) VALUES (${orgA}, 'A', ${orgA}) ON CONFLICT (id) DO NOTHING`;
+    await sql`INSERT INTO organization (id, name, slug) VALUES (${orgB}, 'B', ${orgB}) ON CONFLICT (id) DO NOTHING`;
+  });
+
+  test("getReports filters by organization_id", async () => {
+    const sql = await getSql();
+
+    await createReport(sql, {
+      report_type: "weekly",
+      title: "A — week 1",
+      period_start: "2026-04-27T00:00:00Z",
+      period_end: "2026-05-04T00:00:00Z",
+      orgId: orgA,
+    });
+    await createReport(sql, {
+      report_type: "weekly",
+      title: "B — week 1",
+      period_start: "2026-04-27T00:00:00Z",
+      period_end: "2026-05-04T00:00:00Z",
+      orgId: orgB,
+    });
+
+    const aReports = await getReports(sql, 50, orgA);
+    const bReports = await getReports(sql, 50, orgB);
+
+    expect(aReports.every((r: any) => r.organization_id === orgA)).toBe(true);
+    expect(bReports.every((r: any) => r.organization_id === orgB)).toBe(true);
+    // Cross-org leakage check.
+    expect(aReports.some((r: any) => r.organization_id === orgB)).toBe(false);
+  });
+
+  test("getReportsForOrg returns the row for (org, type, period)", async () => {
+    const sql = await getSql();
+    const row = await getReportsForOrg(
+      sql,
+      orgA,
+      "weekly",
+      "2026-04-27T00:00:00Z"
+    );
+    expect(row).not.toBeNull();
+    expect((row as any).organization_id).toBe(orgA);
+    expect((row as any).report_type).toBe("weekly");
+  });
+
+  test("getReportsForOrg is null for an unknown period", async () => {
+    const sql = await getSql();
+    const row = await getReportsForOrg(
+      sql,
+      orgA,
+      "weekly",
+      "1999-01-01T00:00:00Z"
+    );
+    expect(row).toBeNull();
+  });
+
+  test("createReportIfAbsent skips writes when the weekly-dedup index trips", async () => {
+    const sql = await getSql();
+    const period = "2026-05-04T00:00:00Z";
+
+    const first = await createReportIfAbsent(sql, {
+      report_type: "weekly",
+      title: "A — dedup first",
+      period_start: period,
+      orgId: orgA,
+    });
+    expect(first).not.toBeNull();
+
+    const second = await createReportIfAbsent(sql, {
+      report_type: "weekly",
+      title: "A — dedup second",
+      period_start: period,
+      orgId: orgA,
+    });
+    // Cron foundation: second insert silently skipped, no exception thrown.
+    expect(second).toBeNull();
+
+    // Same (type, period) is allowed for a different org.
+    const otherOrg = await createReportIfAbsent(sql, {
+      report_type: "weekly",
+      title: "B — same period",
+      period_start: period,
+      orgId: orgB,
+    });
+    expect(otherOrg).not.toBeNull();
+  });
+});

--- a/packages/backend/src/db/aiQueries.ts
+++ b/packages/backend/src/db/aiQueries.ts
@@ -237,14 +237,13 @@ export async function createReport(
     title: string;
     period_start?: string;
     period_end?: string;
-    orgId?: string;
+    orgId: string;
     userId?: string;
   }
 ): Promise<AiReport> {
   const id = crypto.randomUUID();
   const periodStart = report.period_start ?? null;
   const periodEnd = report.period_end ?? null;
-  const orgId = report.orgId ?? null;
   const userId = report.userId ?? null;
 
   await sql`
@@ -252,10 +251,43 @@ export async function createReport(
     VALUES (${id}, ${report.report_type}, ${report.title}, 'generating',
       ${periodStart ? sql`${periodStart}::TIMESTAMPTZ` : sql`NULL`},
       ${periodEnd ? sql`${periodEnd}::TIMESTAMPTZ` : sql`NULL`},
-      ${orgId}, ${userId})`;
+      ${report.orgId}, ${userId})`;
 
   const [row] = await sql`SELECT * FROM ai_reports WHERE id = ${id}`;
   return row as AiReport;
+}
+
+/**
+ * Insert a report row only if no row with the same (organization_id, report_type,
+ * period_start) already exists. Returns the inserted row, or `null` if the
+ * weekly-dedup unique index trips. Foundation for the #14 weekly cron (DEV-46) —
+ * lets the cron run idempotently without surrounding transactions.
+ */
+export async function createReportIfAbsent(
+  sql: SQL,
+  report: {
+    report_type: ReportType;
+    title: string;
+    period_start: string;
+    period_end?: string;
+    orgId: string;
+    userId?: string;
+  }
+): Promise<AiReport | null> {
+  const id = crypto.randomUUID();
+  const periodEnd = report.period_end ?? null;
+  const userId = report.userId ?? null;
+
+  const inserted = (await sql`
+    INSERT INTO ai_reports (id, report_type, title, status, period_start, period_end, organization_id, user_id)
+    VALUES (${id}, ${report.report_type}, ${report.title}, 'generating',
+      ${report.period_start}::TIMESTAMPTZ,
+      ${periodEnd ? sql`${periodEnd}::TIMESTAMPTZ` : sql`NULL`},
+      ${report.orgId}, ${userId})
+    ON CONFLICT DO NOTHING
+    RETURNING *`) as AiReport[];
+
+  return inserted[0] ?? null;
 }
 
 export async function updateReport(
@@ -295,6 +327,28 @@ export async function getReports(
     SELECT * FROM ai_reports
     ORDER BY created_at DESC
     LIMIT ${limit}`) as AiReport[];
+}
+
+/**
+ * Org-scoped lookup keyed on the weekly-dedup tuple. Returns at most one row
+ * thanks to the partial unique index on (organization_id, report_type, period_start)
+ * for `report_type = 'weekly'`. For non-weekly types this returns the most
+ * recent matching row, since other types can have multiple rows per period.
+ */
+export async function getReportsForOrg(
+  sql: SQL,
+  orgId: string,
+  reportType: ReportType,
+  periodStart: string
+): Promise<AiReport | null> {
+  const [row] = await sql`
+    SELECT * FROM ai_reports
+    WHERE organization_id = ${orgId}
+      AND report_type = ${reportType}
+      AND period_start = ${periodStart}::TIMESTAMPTZ
+    ORDER BY created_at DESC
+    LIMIT 1`;
+  return (row as AiReport) ?? null;
 }
 
 export async function getReport(

--- a/packages/backend/src/db/migrations/034_ai_reports_org_required.sql
+++ b/packages/backend/src/db/migrations/034_ai_reports_org_required.sql
@@ -1,0 +1,44 @@
+-- DEV-43: Make ai_reports.organization_id required + add weekly-cron dedup index.
+--
+-- Foundation for #14 Weekly Team Report (per the DEV-37 plan, child of DEV-39).
+-- Migration 008 added organization_id as nullable; the weekly cron child (DEV-46)
+-- needs (a) a guarantee every report is tenant-scoped and (b) a dedup constraint
+-- so the cron can use ON CONFLICT DO NOTHING.
+--
+-- Steps (each idempotent so re-running on steady-state is a no-op):
+--   1. Backfill organization_id for any pre-008 rows from the user_id <-> member
+--      mapping. We pick the user's lowest-id membership deterministically; users
+--      with multiple orgs are extremely rare in practice (early dev/test data).
+--   2. Hard-delete rows still missing org binding -- no safe attribution path.
+--   3. ALTER COLUMN ... SET NOT NULL (idempotent on already-NOT-NULL columns).
+--   4. Partial UNIQUE index on (organization_id, report_type, period_start)
+--      restricted to weekly + non-null period_start. Doubles as the cron lookup
+--      index; existing daily/session/custom rows are unaffected.
+
+-- 1. Backfill from member table (Better Auth uses camelCase columns).
+UPDATE ai_reports r
+SET organization_id = m."organizationId"
+FROM member m
+WHERE r.organization_id IS NULL
+  AND r.user_id IS NOT NULL
+  AND m."userId" = r.user_id
+  AND m."organizationId" = (
+    SELECT MIN(m2."organizationId")
+    FROM member m2
+    WHERE m2."userId" = r.user_id
+  );
+
+-- 2. Orphans -- predate org-scoping and have no user_id either. Cannot be
+--    attributed to any tenant; safest to drop. Pilot prod has zero in steady
+--    state; dry-run on a pg_dump restore should confirm before promoting.
+DELETE FROM ai_reports WHERE organization_id IS NULL;
+
+-- 3. Enforce NOT NULL.
+ALTER TABLE ai_reports ALTER COLUMN organization_id SET NOT NULL;
+
+-- 4. Weekly-cron dedup + lookup. Partial unique so it does not collide with
+--    existing rows of other report_types and tolerates legacy rows without
+--    period_start.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_reports_weekly_dedup
+  ON ai_reports (organization_id, report_type, period_start)
+  WHERE report_type = 'weekly' AND period_start IS NOT NULL;

--- a/packages/backend/src/routes/ai.ts
+++ b/packages/backend/src/routes/ai.ts
@@ -274,10 +274,17 @@ export function aiRoutes(sql: SQL) {
     const orgId = c.get("orgId" as never) as string | undefined;
     const devIds = c.get("orgDeveloperIds" as never) as string[] | undefined;
 
+    // Reports are tenant-scoped at the DB layer (DEV-43). Without an active
+    // org we have no row to write — surface a 400 instead of orphaning.
+    if (!orgId) {
+      return c.json({ error: "No active organization" }, 400);
+    }
+
     // Run async — respond immediately with report ID
     const report = await runReportWorkflow(
       sql,
       report_type as ReportType,
+      orgId,
       title,
       period_start,
       period_end,
@@ -352,8 +359,12 @@ export function aiRoutes(sql: SQL) {
       return c.json(cached[0]);
     }
 
-    // Generate new feedback
-    const report = await runSessionFeedbackWorkflow(sql, session_id, privacyMode, isSelfView);
+    // Generate new feedback. orgId is required (DEV-43) so reports are
+    // tenant-scoped at the DB layer.
+    if (!orgId) {
+      return c.json({ error: "No active organization" }, 400);
+    }
+    const report = await runSessionFeedbackWorkflow(sql, session_id, privacyMode, isSelfView, orgId);
 
     if (orgId) {
       broadcastToOrg(orgId, { type: "ai.report.completed", data: report });


### PR DESCRIPTION
## Summary

Foundation for the #14 Weekly Team Report ([DEV-37 plan](/DEV/issues/DEV-37#document-plan), [DEV-43](/DEV/issues/DEV-43)). Additive: migration 008 already added `organization_id` as nullable; this change makes it required and adds the weekly-cron dedup constraint that [DEV-46](/DEV/issues/DEV-46) will use.

- Migration `034_ai_reports_org_required.sql` — backfill `organization_id` from `member.userId` for any pre-008 rows, drop orphans, `SET NOT NULL`, add partial `UNIQUE (organization_id, report_type, period_start) WHERE report_type='weekly' AND period_start IS NOT NULL`. Doubles as the cron lookup index; idempotent on re-run.
- `aiQueries.ts` — `createReport` now requires `orgId`; new `createReportIfAbsent` helper for the cron's dedup-aware insert (returns `null` on conflict); new `getReportsForOrg(orgId, type, periodStart)` for the (org, type, period) lookup.
- `reportWorkflow.ts` + `sessionFeedbackWorkflow.ts` — thread `orgId` through langgraph state into `createReport`. No prompt-template changes; the DEV-44 weekly-buyer prompt branch and DEV-45 mission-guardrail snapshot test stay green untouched.
- `routes/ai.ts` — 400 instead of orphaning a row when there's no active org.
- Integration test `aiQueries.test.ts` (gated on `TEST_DATABASE_URL`, same pattern as `delete-org.test.ts`): cross-org isolation in `getReports`, `getReportsForOrg` happy-path + miss, weekly-dedup `ON CONFLICT DO NOTHING` cron foundation.

## Test plan

- [ ] Backend test suite green (currently 277 pass; the 3 "fail" lines in aggregate output are pre-existing teardown stderr in `cleanupStaleSessions`, `ethicsAudit`, and `validator` — each file passes when run individually).
- [ ] Migration dry-run on a pg_dump of prod restored locally (DEV-24 pattern) — confirm zero orphaned rows are dropped, `SET NOT NULL` succeeds, and the unique index builds.
- [ ] Re-run the migration on the same DB — verify it's a no-op.
- [ ] With `TEST_DATABASE_URL` set, `bun test packages/backend/src/db/__tests__/aiQueries.test.ts` passes 5/5.

## Out of scope (handed off to follow-up children)

- Weekly cron job + per-org loop — [DEV-46](/DEV/issues/DEV-46) (will use `createReportIfAbsent` + `getReportsForOrg`).
- Dashboard `/reports/weekly` filter view — [DEV-47](/DEV/issues/DEV-47).
- Mission-guardrail snapshot test — [DEV-45](/DEV/issues/DEV-45) (in-flight on a separate branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)