### PR TITLE
DEV-68: await autoLinkDeveloperToOrg to fix first-event WS broadcast race

### DIFF
--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -748,6 +748,49 @@ describe("POST /events", () => {
     expect(orgIds).toContain("org-1");
     expect(orgIds).toContain("org-2");
   });
+
+  // -----------------------------------------------------------------------
+  // DEV-68: first-event WS broadcast race
+  // -----------------------------------------------------------------------
+
+  test("awaits autoLinkDeveloperToOrg so a fresh developer's first event broadcasts", async () => {
+    // Regression for DEV-68. Previously autoLinkDeveloperToOrg was
+    // fire-and-forget, so the very first event from a brand-new developerId
+    // was persisted but not broadcast — the WS fan-out in
+    // runPostInsertHandlers queried organization_developer before the link
+    // insert had landed, devOrgs came back empty, and broadcastToOrg was
+    // never called. Subsequent events from the same dev id worked because
+    // the row was now in place.
+    const sql = makeMockSql([], []); // no existing session, no org rows initially
+
+    // Simulate the link insert landing on a macrotask boundary — AFTER all
+    // synchronous microtasks. If the route still fires-and-forgets the link
+    // (buggy version), runPostInsertHandlers will see orgRows = [] and
+    // broadcast nothing. If the route awaits the link (fix), the org row is
+    // in place before the broadcast fan-out runs.
+    mockAutoLinkDeveloperToOrg.mockImplementation(async () => {
+      await new Promise<void>((r) => setTimeout(r, 0));
+      sql._setOrgRows([{ organization_id: "org-fresh" }]);
+    });
+
+    const app = buildApp(sql, { apiKeyUserId: "user-owner-1" });
+
+    await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validEvent()),
+    });
+
+    expect(mockAutoLinkDeveloperToOrg).toHaveBeenCalledTimes(1);
+    // The broadcast must reach the just-linked org bucket.
+    const orgIds = mockBroadcastToOrg.mock.calls.map((c: any) => c[0]);
+    expect(orgIds).toContain("org-fresh");
+    // event.new in particular must fire — that's the user-visible bug.
+    const types = mockBroadcastToOrg.mock.calls.map(
+      (c: any) => (c[1] as any).type,
+    );
+    expect(types).toContain("event.new");
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -836,6 +879,46 @@ describe("POST /events/hook", () => {
 
     expect(res.status).toBe(401);
     expect(mockInsertEvent).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // DEV-68: first-event WS broadcast race (hook path)
+  // -----------------------------------------------------------------------
+
+  test("awaits autoLinkDeveloperToOrg so a fresh developer's first hook event broadcasts", async () => {
+    // Regression for DEV-68 on the /hook path. Mirrors the POST / case:
+    // both ingestion paths must broadcast the very first event from a
+    // brand-new developerId, not just persist it.
+    const sql = makeMockSql([], []);
+
+    mockBroadcastToOrg.mockReset();
+    mockAutoLinkDeveloperToOrg.mockImplementation(async () => {
+      await new Promise<void>((r) => setTimeout(r, 0));
+      sql._setOrgRows([{ organization_id: "org-fresh-hook" }]);
+    });
+
+    const app = buildApp(sql, {
+      apiKeyUserId: "user-owner-1",
+      user: { id: "user-owner-1", name: "Alice", email: "alice@example.com" },
+    });
+
+    const res = await app.request("/hook?event=notification", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: "sess-hook-fresh",
+        cwd: "/home/alice/proj",
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockAutoLinkDeveloperToOrg).toHaveBeenCalledTimes(1);
+    const orgIds = mockBroadcastToOrg.mock.calls.map((c: any) => c[0]);
+    expect(orgIds).toContain("org-fresh-hook");
+    const types = mockBroadcastToOrg.mock.calls.map(
+      (c: any) => (c[1] as any).type,
+    );
+    expect(types).toContain("event.new");
   });
 });
 

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -220,9 +220,16 @@ export function eventsRoutes(sql: SQL) {
     // Auto-link plugin developer to the API key owner's org
     const apiKeyUserId = c.get("apiKeyUserId" as never) as string | undefined;
     if (apiKeyUserId) {
-      // Best-effort linking — must not block or abort event ingestion
-      autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
+      // DEV-68: await the org link before any code that queries
+      // organization_developer (privacy_mode_activated logging below and the
+      // broadcast fan-out in runPostInsertHandlers). Otherwise the very first
+      // event from a brand-new developerId is persisted but not broadcast
+      // because the link insert hasn't landed when the lookup runs.
+      // Errors are still caught so a failed link does not abort ingestion.
+      await autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
         .catch((err) => console.error("[events] autoLinkDeveloperToOrg failed:", err));
+      // autoLinkUserToDeveloper is not on the broadcast critical path; keep
+      // it fire-and-forget so we don't add an extra round-trip per event.
       autoLinkUserToDeveloper(sql, apiKeyUserId, event.developerId)
         .catch((err) => console.error("[events] autoLinkUserToDeveloper failed:", err));
     }
@@ -495,7 +502,11 @@ export function eventsRoutes(sql: SQL) {
 
     // Upsert developer
     await upsertDeveloper(sql, event.developerId, event.developerName, event.developerEmail ?? "");
-    autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
+    // DEV-68: await the org link before runPostInsertHandlers so the very first
+    // event from a brand-new developerId actually broadcasts (the WS fan-out
+    // queries organization_developer, which would otherwise be empty on race).
+    // Errors are still caught so a failed link does not abort ingestion.
+    await autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
       .catch((err) => console.error("[events/hook] autoLinkDeveloperToOrg failed:", err));
     autoLinkUserToDeveloper(sql, apiKeyUserId, event.developerId)
       .catch((err) => console.error("[events/hook] autoLinkUserToDeveloper failed:", err));


### PR DESCRIPTION
## Summary

Fixes [DEV-68](/DEV/issues/DEV-68): the very first event from a brand-new `developerId` is persisted but not broadcast over WebSocket.

`autoLinkDeveloperToOrg` was fire-and-forget in both `POST /api/events` and `POST /api/events/hook`, so `runPostInsertHandlers` could query `organization_developer` before the link insert landed → `devOrgs` empty → `broadcastToOrg` never called. Subsequent events from the same dev id worked (row was now in place), which is exactly why this slipped past local smoke testing.

- Await the link on both ingestion paths before any code that reads `organization_developer` (broadcast fan-out and the `privacy_mode_activated` ethics log).
- `.catch()` is preserved so a failed link does not abort ingestion.
- `autoLinkUserToDeveloper` stays fire-and-forget — it's not on the broadcast critical path.

Backend-only change. No event-shape change, so no plugin lockstep is needed.

## Test plan

- [x] New regression test in `routes/__tests__/events.test.ts` for `POST /` — fresh developer, link landing on a macrotask boundary, asserts `event.new` is broadcast to the just-linked org bucket.
- [x] Mirror test for `POST /hook`.
- [x] Verified the new tests fail without the fix (39 pass / 2 fail) and pass with it (41 pass / 0 fail).
- [x] Existing 39 events tests untouched and passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)