### PR TITLE
DEV-48: doc-gap helper + weekly-buyer prompt slot fill

### DIFF
--- a/packages/backend/src/__test_helpers__/mockStubs.ts
+++ b/packages/backend/src/__test_helpers__/mockStubs.ts
@@ -78,6 +78,7 @@ export function dbStubs(overrides: Record<string, unknown> = {}) {
     getClaudeMdTimeline: noopArr,
     getClaudeMdProjects: noopArr,
     computeClaudeMdCorrelation: noop,
+    getDocGapsForOrg: noopArr,
     // topologyQueries.ts
     computeTeamToolTopology: noop,
     getTeamToolTopology: noopArr,

--- a/packages/backend/src/ai/workflows/reportWorkflow.ts
+++ b/packages/backend/src/ai/workflows/reportWorkflow.ts
@@ -17,6 +17,7 @@ import {
   recordTokenUsage,
   createReport,
   updateReport,
+  getDocGapsForOrg,
 } from "../../db";
 import type { AiReport, ReportType } from "@devscope/shared";
 
@@ -180,6 +181,25 @@ export async function gatherReportData(
     orgId: state.orgId,
   });
 
+  // DEV-48 doc-gap subsection — only computed for the weekly-buyer persona
+  // because the prompt slot lives on that persona only. Resolved here so the
+  // mission guardrail tripwire in `generateOutline` covers the full payload.
+  // If the helper has nothing to report (no CLAUDE.md snapshots, no period
+  // bounds, or no candidate terms), the field is omitted and the prompt's
+  // "Doc gap data unavailable" branch handles the absence gracefully.
+  let docGaps: Awaited<ReturnType<typeof getDocGapsForOrg>> | undefined;
+  if (
+    state.persona === WEEKLY_BUYER_PERSONA &&
+    state.periodStart &&
+    state.periodEnd &&
+    state.orgId
+  ) {
+    docGaps = await getDocGapsForOrg(sql, state.orgId, {
+      start: state.periodStart,
+      end: state.periodEnd,
+    });
+  }
+
   return {
     data: {
       periodComparison,
@@ -194,6 +214,7 @@ export async function gatherReportData(
       failureClusters,
       effectivePatterns,
       antiPatternSummary,
+      ...(docGaps && docGaps.length > 0 ? { docGaps } : {}),
     },
     reportId: report.id,
   };

--- a/packages/backend/src/ai/workflows/reportWorkflow.ts
+++ b/packages/backend/src/ai/workflows/reportWorkflow.ts
@@ -187,6 +187,12 @@ export async function gatherReportData(
   // If the helper has nothing to report (no CLAUDE.md snapshots, no period
   // bounds, or no candidate terms), the field is omitted and the prompt's
   // "Doc gap data unavailable" branch handles the absence gracefully.
+  //
+  // Failure mode: `createReport` above has already inserted a pending report
+  // row, so a thrown error from the helper would orphan that record AND
+  // abort the report. The doc-gap subsection is a wedge enhancement, not a
+  // load-bearing field — degrade by logging and omitting `docGaps` so the
+  // rest of the report still ships.
   let docGaps: Awaited<ReturnType<typeof getDocGapsForOrg>> | undefined;
   if (
     state.persona === WEEKLY_BUYER_PERSONA &&
@@ -194,10 +200,19 @@ export async function gatherReportData(
     state.periodEnd &&
     state.orgId
   ) {
-    docGaps = await getDocGapsForOrg(sql, state.orgId, {
-      start: state.periodStart,
-      end: state.periodEnd,
-    });
+    try {
+      docGaps = await getDocGapsForOrg(sql, state.orgId, {
+        start: state.periodStart,
+        end: state.periodEnd,
+      });
+    } catch (err) {
+      console.warn(
+        `[gatherReportData] getDocGapsForOrg failed for org=${state.orgId} ` +
+          `period=${state.periodStart}..${state.periodEnd} — ` +
+          `omitting docGaps from this report.`,
+        err
+      );
+    }
   }
 
   return {

--- a/packages/backend/src/db/__tests__/getDocGapsForOrg.test.ts
+++ b/packages/backend/src/db/__tests__/getDocGapsForOrg.test.ts
@@ -1,0 +1,276 @@
+/**
+ * DEV-48 — `getDocGapsForOrg` deterministic + mission-guardrail snapshot.
+ *
+ * The helper feeds the `weekly-buyer` persona's `docGaps` prompt slot. The
+ * acceptance criteria from DEV-48 are:
+ *
+ *   1. Deterministic results on a synthetic seed dataset.
+ *   2. Output passes the mission-guardrail snapshot test (no per-dev strings).
+ *   3. Zero new event types or rollup jobs added — the helper rides on the
+ *      existing `events` + `claude_md_snapshots` tables.
+ *
+ * This test mocks `sql` to serve the helper the four query shapes it issues
+ * (latest snapshot text, grep patterns, file basenames, glob directories)
+ * with a synthetic team of three developers underneath. The helper's output
+ * is asserted to be:
+ *   - exactly the deterministic top-N list (count desc, kind asc, term asc),
+ *   - free of any synthetic team's identifying strings, and
+ *   - additionally clean per the runtime mission-guardrail detector.
+ */
+
+import { describe, expect, test, beforeEach } from "bun:test";
+import { getDocGapsForOrg } from "../claudeMdQueries";
+import {
+  detectDeveloperIdentities,
+  _resetMissionRosterCache,
+} from "../../ai/grounding/missionGuardrail";
+
+// ---------------------------------------------------------------------------
+// Synthetic team — same shape as DEV-45 fixture so a future helper change
+// that accidentally piped per-developer data through would be caught here too.
+// ---------------------------------------------------------------------------
+
+const TEAM = [
+  {
+    id: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+    name: "Alice Johnson",
+    email: "alice@acme.test",
+  },
+  {
+    id: "b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1",
+    name: "Bob Patel",
+    email: "bob@acme.test",
+  },
+  {
+    id: "c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2",
+    name: "Carol Lee",
+    email: "carol@acme.test",
+  },
+];
+
+// Latest CLAUDE.md content for the org, lower-cased on read by the helper.
+// "deploy" and "stripe" are explicitly documented; everything else in the
+// candidate rows below should fall through as gap candidates.
+const CLAUDE_MD_CORPUS = `
+# Project conventions
+
+Use \`bun test\` to run the unit suite.
+Deployment uses the deploy.sh script in tools/.
+Stripe webhooks are mocked in tests/fixtures/stripe.
+
+## Architecture
+
+Read packages/backend/CLAUDE.md before touching the API surface.
+`;
+
+// The four query shapes the helper issues. Order matters because the helper
+// calls them in the order: snapshots, grep, files, dirs.
+function createMockSql() {
+  let callIndex = 0;
+  const responses: unknown[][] = [
+    // 1. Snapshots — latest content_text per project_path for the org.
+    [{ content_text: CLAUDE_MD_CORPUS }],
+
+    // 2. Grep/Glob patterns. "deploy" and "stripe" are covered by the corpus
+    //    and MUST be filtered out by the helper. Sample sessions are UUIDs
+    //    (under the 16-hex SHA-256 threshold of the mission guardrail).
+    [
+      {
+        term: "telemetry",
+        count: 42,
+        sample_session_ids: [
+          "11111111-1111-4111-8111-111111111111",
+          "22222222-2222-4222-8222-222222222222",
+        ],
+      },
+      {
+        term: "feature_flag",
+        count: 31,
+        sample_session_ids: ["33333333-3333-4333-8333-333333333333"],
+      },
+      {
+        term: "deploy",
+        count: 28,
+        sample_session_ids: ["44444444-4444-4444-8444-444444444444"],
+      },
+      {
+        term: "rate_limit",
+        count: 14,
+        sample_session_ids: ["55555555-5555-4555-8555-555555555555"],
+      },
+    ],
+
+    // 3. File basenames (the helper strips the directory).
+    [
+      {
+        term: "ratelimiter.ts",
+        count: 22,
+        sample_session_ids: ["66666666-6666-4666-8666-666666666666"],
+      },
+      {
+        term: "stripe.ts",
+        count: 18, // covered by corpus ("stripe") — should drop
+        sample_session_ids: ["77777777-7777-4777-8777-777777777777"],
+      },
+      {
+        term: "telemetry-shim.ts",
+        count: 9, // covered transitively via "telemetry" but the corpus
+        // doesn't contain "telemetry-shim" — should NOT drop, because the
+        // helper checks the full term against the corpus, not a substring.
+        sample_session_ids: ["88888888-8888-4888-8888-888888888888"],
+      },
+    ],
+
+    // 4. Glob directories.
+    [
+      {
+        term: "infra/terraform",
+        count: 16,
+        sample_session_ids: ["99999999-9999-4999-8999-999999999999"],
+      },
+    ],
+  ];
+
+  const fn = (..._args: unknown[]) => {
+    const next = responses[callIndex] ?? [];
+    callIndex += 1;
+    return Promise.resolve(next);
+  };
+  return Object.assign(fn, {
+    begin: async (cb: (tx: unknown) => Promise<void>) => {
+      await cb((..._a: unknown[]) => Promise.resolve([]));
+    },
+  }) as any;
+}
+
+// Mission-guardrail mock SQL — separate fn that always returns the synthetic
+// roster from the developers table so `detectDeveloperIdentities` can score
+// the helper output against it.
+function createRosterSql() {
+  const fn = (..._args: unknown[]) => Promise.resolve(TEAM);
+  return Object.assign(fn, {
+    begin: async (cb: (tx: unknown) => Promise<void>) => {
+      await cb((..._a: unknown[]) => Promise.resolve([]));
+    },
+  }) as any;
+}
+
+describe("DEV-48 getDocGapsForOrg", () => {
+  beforeEach(() => {
+    _resetMissionRosterCache();
+  });
+
+  test("deterministic ranking and CLAUDE.md filtering on synthetic seed", async () => {
+    const sql = createMockSql();
+    const period = { start: "2026-04-27T00:00:00Z", end: "2026-05-03T00:00:00Z" };
+
+    const gaps = await getDocGapsForOrg(sql, "org-test-1", period);
+
+    // Expected result: covered terms ("deploy", "stripe.ts") dropped; the rest
+    // ranked by count desc with ties broken on (kind asc, term asc).
+    expect(gaps).toEqual([
+      {
+        term: "telemetry",
+        kind: "grep_pattern",
+        count: 42,
+        sample_session_ids: [
+          "11111111-1111-4111-8111-111111111111",
+          "22222222-2222-4222-8222-222222222222",
+        ],
+      },
+      {
+        term: "feature_flag",
+        kind: "grep_pattern",
+        count: 31,
+        sample_session_ids: ["33333333-3333-4333-8333-333333333333"],
+      },
+      {
+        term: "ratelimiter.ts",
+        kind: "file_path",
+        count: 22,
+        sample_session_ids: ["66666666-6666-4666-8666-666666666666"],
+      },
+      {
+        term: "infra/terraform",
+        kind: "directory",
+        count: 16,
+        sample_session_ids: ["99999999-9999-4999-8999-999999999999"],
+      },
+      {
+        term: "rate_limit",
+        kind: "grep_pattern",
+        count: 14,
+        sample_session_ids: ["55555555-5555-4555-8555-555555555555"],
+      },
+      {
+        term: "telemetry-shim.ts",
+        kind: "file_path",
+        count: 9,
+        sample_session_ids: ["88888888-8888-4888-8888-888888888888"],
+      },
+    ]);
+  });
+
+  test("returns [] when org has no CLAUDE.md snapshot", async () => {
+    let callIndex = 0;
+    const fn = (..._args: unknown[]) => {
+      callIndex += 1;
+      return Promise.resolve([]); // empty snapshots → bail
+    };
+    const sql = Object.assign(fn, {
+      begin: async () => {},
+    }) as any;
+
+    const gaps = await getDocGapsForOrg(sql, "org-empty", {
+      start: "2026-04-27T00:00:00Z",
+      end: "2026-05-03T00:00:00Z",
+    });
+    expect(gaps).toEqual([]);
+    // Bailed out after the snapshot query — must not have run the candidate
+    // queries (this is the "no CLAUDE.md, don't declare every search a gap"
+    // contract).
+    expect(callIndex).toBe(1);
+  });
+
+  test("respects custom limit", async () => {
+    const sql = createMockSql();
+    const gaps = await getDocGapsForOrg(
+      sql,
+      "org-test-1",
+      { start: "2026-04-27T00:00:00Z", end: "2026-05-03T00:00:00Z" },
+      3
+    );
+    expect(gaps).toHaveLength(3);
+    expect(gaps.map((g) => g.term)).toEqual([
+      "telemetry",
+      "feature_flag",
+      "ratelimiter.ts",
+    ]);
+  });
+
+  test("mission guardrail: helper output has zero developer-identifying strings", async () => {
+    const sql = createMockSql();
+    const gaps = await getDocGapsForOrg(sql, "org-test-1", {
+      start: "2026-04-27T00:00:00Z",
+      end: "2026-05-03T00:00:00Z",
+    });
+
+    const serialized = JSON.stringify(gaps);
+    for (const dev of TEAM) {
+      expect(serialized).not.toContain(dev.email);
+      expect(serialized).not.toContain(dev.id);
+      const firstName = dev.name.split(/\s+/)[0];
+      expect(serialized).not.toContain(firstName);
+    }
+    expect(/\bapikey-[A-Za-z0-9_-]+/.test(serialized)).toBe(false);
+    // No 16+ contiguous hex run — UUIDs in sample_session_ids are
+    // dash-separated and don't trigger the mission guardrail.
+    expect(/[0-9a-fA-F]{16,}/.test(serialized)).toBe(false);
+
+    // Belt-and-braces: run the runtime detector against the helper output
+    // with the synthetic team loaded as the roster.
+    const rosterSql = createRosterSql();
+    const hits = await detectDeveloperIdentities(rosterSql, gaps);
+    expect(hits).toEqual([]);
+  });
+});

--- a/packages/backend/src/db/__tests__/getDocGapsForOrg.test.ts
+++ b/packages/backend/src/db/__tests__/getDocGapsForOrg.test.ts
@@ -114,9 +114,12 @@ function createMockSql() {
       },
       {
         term: "telemetry-shim.ts",
-        count: 9, // covered transitively via "telemetry" but the corpus
-        // doesn't contain "telemetry-shim" — should NOT drop, because the
-        // helper checks the full term against the corpus, not a substring.
+        count: 9,
+        // Falls through as a gap: neither the full term "telemetry-shim.ts"
+        // nor its extension-stripped stem "telemetry-shim" appears as a
+        // substring of CLAUDE_MD_CORPUS. Confirms the stem-strip heuristic
+        // is tight (covers "stripe" → "stripe.ts") and does not over-cover
+        // (a doc mentioning only "shim" must NOT cover "telemetry-shim.ts").
         sample_session_ids: ["88888888-8888-4888-8888-888888888888"],
       },
     ],

--- a/packages/backend/src/db/claudeMdQueries.ts
+++ b/packages/backend/src/db/claudeMdQueries.ts
@@ -3,6 +3,8 @@ import type {
   ClaudeMdSnapshot,
   ClaudeMdCorrelation,
   ClaudeMdTimelineEntry,
+  DocGapCandidate,
+  DocGapPeriod,
 } from "@devscope/shared";
 
 export async function upsertClaudeMdSnapshot(
@@ -220,4 +222,186 @@ export async function computeClaudeMdCorrelation(
     SELECT * FROM claude_md_correlations WHERE snapshot_id = ${snapshotId}
   `;
   return existing as ClaudeMdCorrelation;
+}
+
+// --------------------------------------------------------------------------
+// Doc-gap helper (DEV-48)
+// --------------------------------------------------------------------------
+
+/**
+ * Surface the top recurring search/read terms in an org's events that do NOT
+ * appear in the org's most recent CLAUDE.md snapshots — i.e. candidate
+ * documentation gaps for the weekly-buyer report. Team-aggregate by
+ * construction: every returned field is a tool-side primitive (search
+ * pattern, file basename, directory, count, session UUID). Per the DEV-37
+ * mission guardrail, no developer ids, names, or emails are read or
+ * returned.
+ *
+ * Algorithm (kept intentionally simple — this is a wedge differentiator,
+ * not a search engine):
+ *
+ *   1. Build a single lower-cased "corpus" of the latest CLAUDE.md snapshot
+ *      per project_path for the org. A term is considered "covered" if its
+ *      lower-cased form appears as a substring in this corpus.
+ *   2. Query top Grep/Glob `pattern`, top Read/Write/Edit file basenames,
+ *      and top Glob `path` directories from events in the period for
+ *      sessions belonging to developers in this org. Each candidate row
+ *      carries up to 3 distinct sample session UUIDs.
+ *   3. Drop any candidate whose term is covered by the corpus, drop empty
+ *      / single-char terms, and return the top `limit` by count with a
+ *      stable tie-break on `term ASC` for deterministic output.
+ *
+ * Returns `[]` if the org has no developers or no recent CLAUDE.md snapshot.
+ */
+export async function getDocGapsForOrg(
+  sql: SQL,
+  orgId: string,
+  period: DocGapPeriod,
+  limit = 8
+): Promise<DocGapCandidate[]> {
+  // 1. Latest CLAUDE.md snapshot per project_path for this org. We join the
+  //    text content into one lower-cased corpus for cheap substring lookup.
+  const snapshotRows = (await sql`
+    SELECT DISTINCT ON (project_path) content_text
+    FROM claude_md_snapshots
+    WHERE organization_id = ${orgId}
+      AND content_text IS NOT NULL
+    ORDER BY project_path, captured_at DESC
+  `) as Array<{ content_text: string | null }>;
+
+  if (snapshotRows.length === 0) {
+    // No CLAUDE.md to compare against — bail out rather than declare every
+    // search term a "gap".
+    return [];
+  }
+
+  const corpus = snapshotRows
+    .map((r) => (r.content_text ?? "").toLowerCase())
+    .join("\n");
+
+  // 2. Pull candidate terms in three categories. We deliberately use the
+  //    same `payload->>'toolName'` filters as `getConcreteToolDetails` so the
+  //    helper rides on the existing `idx_events_payload_toolname` GIN index.
+  //    Org scoping joins via `organization_developer`. Sample sessions are
+  //    UUIDs (under the 16-hex SHA-256 threshold of the mission guardrail).
+
+  // Grep/Glob patterns
+  const grepRows = (await sql`
+    SELECT
+      e.payload->'toolInput'->>'pattern'                                    AS term,
+      COUNT(*)::INT                                                          AS count,
+      (ARRAY_AGG(DISTINCT e.session_id ORDER BY e.session_id))[1:3]          AS sample_session_ids
+    FROM events e
+    JOIN sessions s ON e.session_id = s.id
+    JOIN organization_developer od ON od.developer_id = s.developer_id
+    WHERE od.organization_id = ${orgId}
+      AND e.event_type IN ('tool.complete', 'tool.fail')
+      AND e.payload->>'toolName' IN ('Grep', 'Glob')
+      AND e.payload->'toolInput'->>'pattern' IS NOT NULL
+      AND length(e.payload->'toolInput'->>'pattern') >= 2
+      AND s.privacy_mode IS DISTINCT FROM 'private'
+      AND e.created_at >= ${period.start}::timestamptz
+      AND e.created_at <  ${period.end}::timestamptz
+    GROUP BY term
+    ORDER BY count DESC, term ASC
+    LIMIT 50
+  `) as Array<{ term: string; count: number; sample_session_ids: string[] }>;
+
+  // Read/Write/Edit file basenames. We strip the directory because absolute
+  // paths are noisy and the basename is what a CLAUDE.md typically mentions.
+  const fileRows = (await sql`
+    SELECT
+      regexp_replace(e.payload->'toolInput'->>'file_path', '^.*/', '')      AS term,
+      COUNT(*)::INT                                                          AS count,
+      (ARRAY_AGG(DISTINCT e.session_id ORDER BY e.session_id))[1:3]          AS sample_session_ids
+    FROM events e
+    JOIN sessions s ON e.session_id = s.id
+    JOIN organization_developer od ON od.developer_id = s.developer_id
+    WHERE od.organization_id = ${orgId}
+      AND e.event_type IN ('tool.complete', 'tool.fail')
+      AND e.payload->>'toolName' IN ('Read', 'Write', 'Edit')
+      AND e.payload->'toolInput'->>'file_path' IS NOT NULL
+      AND s.privacy_mode IS DISTINCT FROM 'private'
+      AND e.created_at >= ${period.start}::timestamptz
+      AND e.created_at <  ${period.end}::timestamptz
+    GROUP BY term
+    HAVING regexp_replace(e.payload->'toolInput'->>'file_path', '^.*/', '') <> ''
+    ORDER BY count DESC, term ASC
+    LIMIT 50
+  `) as Array<{ term: string; count: number; sample_session_ids: string[] }>;
+
+  // Glob directories
+  const dirRows = (await sql`
+    SELECT
+      e.payload->'toolInput'->>'path'                                       AS term,
+      COUNT(*)::INT                                                          AS count,
+      (ARRAY_AGG(DISTINCT e.session_id ORDER BY e.session_id))[1:3]          AS sample_session_ids
+    FROM events e
+    JOIN sessions s ON e.session_id = s.id
+    JOIN organization_developer od ON od.developer_id = s.developer_id
+    WHERE od.organization_id = ${orgId}
+      AND e.event_type IN ('tool.complete', 'tool.fail')
+      AND e.payload->>'toolName' = 'Glob'
+      AND e.payload->'toolInput'->>'path' IS NOT NULL
+      AND length(e.payload->'toolInput'->>'path') >= 2
+      AND s.privacy_mode IS DISTINCT FROM 'private'
+      AND e.created_at >= ${period.start}::timestamptz
+      AND e.created_at <  ${period.end}::timestamptz
+    GROUP BY term
+    ORDER BY count DESC, term ASC
+    LIMIT 50
+  `) as Array<{ term: string; count: number; sample_session_ids: string[] }>;
+
+  // 3. Filter out terms covered by the latest CLAUDE.md corpus, then merge
+  //    and rank. A term is "covered" if its lower-cased form is a substring
+  //    of the corpus. This is intentionally coarse — it is the same heuristic
+  //    a developer would use when grepping their own CLAUDE.md.
+  const candidates: DocGapCandidate[] = [];
+
+  function isCovered(term: string, kind: DocGapCandidate["kind"]): boolean {
+    const lower = term.toLowerCase();
+    if (corpus.includes(lower)) return true;
+    // For file basenames, also try the extension-stripped stem so that a
+    // CLAUDE.md mentioning "stripe" covers reads of "stripe.ts" /
+    // "stripe.test.ts" without the developer having to enumerate every
+    // extension. Only strip the final extension to keep the heuristic tight
+    // (a file mentioned only as "shim" in the docs should NOT cover
+    // "telemetry-shim.ts").
+    if (kind === "file_path") {
+      const stem = lower.replace(/\.[a-z0-9]+$/i, "");
+      if (stem.length >= 2 && stem !== lower && corpus.includes(stem)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function consider(
+    rows: Array<{ term: string; count: number; sample_session_ids: string[] }>,
+    kind: DocGapCandidate["kind"]
+  ) {
+    for (const row of rows) {
+      const term = (row.term ?? "").trim();
+      if (term.length < 2) continue;
+      if (isCovered(term, kind)) continue;
+      candidates.push({
+        term,
+        kind,
+        count: row.count,
+        sample_session_ids: (row.sample_session_ids ?? []).slice(0, 3),
+      });
+    }
+  }
+
+  consider(grepRows, "grep_pattern");
+  consider(fileRows, "file_path");
+  consider(dirRows, "directory");
+
+  candidates.sort((a, b) => {
+    if (b.count !== a.count) return b.count - a.count;
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
+    return a.term.localeCompare(b.term);
+  });
+
+  return candidates.slice(0, limit);
 }

--- a/packages/shared/src/claudeMd.ts
+++ b/packages/shared/src/claudeMd.ts
@@ -29,3 +29,27 @@ export interface ClaudeMdTimelineEntry {
   snapshot: ClaudeMdSnapshot;
   correlation: ClaudeMdCorrelation | null;
 }
+
+/**
+ * A single recurring search/read term that does not appear in the org's most
+ * recent CLAUDE.md snapshots — i.e. a candidate documentation gap surfaced in
+ * the weekly-buyer report. Team-aggregate by construction: no developer ids
+ * or names, only session UUIDs as sample contexts.
+ */
+export interface DocGapCandidate {
+  /** The literal term as observed in events (search pattern, file basename, or directory). */
+  term: string;
+  /** Source of the term — drives how the report frames it in the bullet. */
+  kind: "grep_pattern" | "file_path" | "directory";
+  /** Number of matching tool events in the period. */
+  count: number;
+  /** Up to 3 distinct session UUIDs where the term appeared (UUIDs only — not developer-identifying). */
+  sample_session_ids: string[];
+}
+
+export interface DocGapPeriod {
+  /** Inclusive ISO timestamp. */
+  start: string;
+  /** Exclusive ISO timestamp. */
+  end: string;
+}


### PR DESCRIPTION
## Summary

Closes the DEV-37 wedge differentiator by populating the `weekly-buyer` persona's documentation-gap subsection. Adds `getDocGapsForOrg(sql, orgId, period, limit)` and threads its result onto `data.docGaps` for that persona only.

- **Helper** (`packages/backend/src/db/claudeMdQueries.ts`): top recurring Grep/Glob patterns, Read/Write/Edit file basenames, and Glob directories that do NOT appear in the org's most recent CLAUDE.md snapshots. Substring corpus check with file-basename stem-strip ("stripe" in CLAUDE.md covers reads of `stripe.ts`). Deterministic ordering (count desc, kind asc, term asc).
- **Wiring** (`reportWorkflow.ts`): `gatherReportData` calls the helper only for `weekly-buyer` with org+period present. The mission guardrail in `generateOutline`/`writeReport` already covers the resulting payload — no new tripwire required.
- **Mission contract**: team-aggregate by construction. No developer ids, names, or emails are read or returned. Sample contexts are session UUIDs (under the 16-hex SHA-256 threshold of the DEV-45 detector).
- **No new event types or rollup jobs.** Rides entirely on existing `events` + `claude_md_snapshots` tables.

## Test plan

- [x] `bun test packages/backend/src/db/__tests__/getDocGapsForOrg.test.ts` — deterministic ranking, CLAUDE.md filtering, empty-org bail, custom limit, mission-guardrail snapshot (5/5 pass).
- [x] `bun test packages/backend/src/ai/workflows/__tests__/reportWorkflow.guardrail.test.ts` — DEV-45 snapshot still passes after adding the new field shape.
- [x] Confirmed pre-existing `events.test.ts` / `ethicsAudit.test.ts` / `validator.test.ts` failures are present on `origin/main` and are not caused by this change.

## References

- Parent: [DEV-39](/DEV/issues/DEV-39)
- Plan: [DEV-37#document-plan](/DEV/issues/DEV-37#document-plan)
- Persona child it slots into: [DEV-44](/DEV/issues/DEV-44)
- Mission guardrail this depends on: [DEV-45](/DEV/issues/DEV-45)
- Issue: [DEV-48](/DEV/issues/DEV-48)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly-buyer reports now include documentation-gap analysis listing recurring missing terms, file/path and directory candidates, and example session references.
* **Types**
  * Added public types modeling doc-gap candidates and report time windows.
* **Tests**
  * Added deterministic tests for ranking, filtering, limits, and anti-identifier guardrails.
* **Chores**
  * Test helper surface updated with a new default no-op stub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->