### PR TITLE
DEV-76: expose org salt + salt_version on session.start; sessions.salt_version migration

### DIFF
--- a/packages/backend/src/db/migrations/036_sessions_salt_version.sql
+++ b/packages/backend/src/db/migrations/036_sessions_salt_version.sql
@@ -1,0 +1,13 @@
+-- DEV-76: Per-session salt-version stamp for plugin-side path/pattern hashing.
+--
+-- Sets up the backend half of the Option-1 wire fix sanctioned on DEV-72.
+-- The plugin (DEV-74) will hash file_path/pattern/path values at emit time
+-- using an org-scoped salt distributed via session.start. We stamp the
+-- salt_version on the session row so a future rotation can disambiguate
+-- which key was in force when the row was written.
+--
+-- The salt itself is NEVER persisted — only the version. See
+-- packages/backend/src/utils/orgSalt.ts for derivation.
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS salt_version SMALLINT NOT NULL DEFAULT 1;

--- a/packages/backend/src/db/queries.ts
+++ b/packages/backend/src/db/queries.ts
@@ -56,11 +56,15 @@ export async function createSession(
   projectPath: string,
   projectName: string,
   permissionMode: string | null,
-  privacyMode: string | null = null
+  privacyMode: string | null = null,
+  saltVersion: number = 1,
 ) {
+  // DEV-76: salt_version is set on first INSERT and intentionally NOT
+  // updated on conflict — once a session has been stamped with a version,
+  // events recorded against it must keep referencing that version.
   await sql`
-    INSERT INTO sessions (id, developer_id, project_path, project_name, permission_mode, privacy_mode)
-    VALUES (${id}, ${developerId}, ${projectPath}, ${projectName}, ${permissionMode}, ${privacyMode})
+    INSERT INTO sessions (id, developer_id, project_path, project_name, permission_mode, privacy_mode, salt_version)
+    VALUES (${id}, ${developerId}, ${projectPath}, ${projectName}, ${permissionMode}, ${privacyMode}, ${saltVersion})
     ON CONFLICT(id) DO UPDATE SET
       permission_mode = COALESCE(EXCLUDED.permission_mode, sessions.permission_mode),
       privacy_mode = COALESCE(EXCLUDED.privacy_mode, sessions.privacy_mode),

--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -130,6 +130,7 @@ function buildApp(
     apiKeyUserId?: string;
     orgDeveloperIds?: string[];
     user?: { id?: string; name?: string; email?: string };
+    session?: { activeOrganizationId?: string };
   } = {},
 ) {
   const app = new Hono();
@@ -143,6 +144,9 @@ function buildApp(
     }
     if (opts.user !== undefined) {
       c.set("user" as never, opts.user as never);
+    }
+    if (opts.session !== undefined) {
+      c.set("session" as never, opts.session as never);
     }
     await next();
   });
@@ -295,6 +299,7 @@ describe("POST /events", () => {
       "my-project",
       null, // permissionMode not set in default payload
       null, // privacyMode not set in default payload
+      1, // DEV-76: CURRENT_SALT_VERSION stamped on the session row
     );
   });
 
@@ -318,7 +323,145 @@ describe("POST /events", () => {
       "my-project",
       "plan",
       "private",
+      1, // DEV-76: CURRENT_SALT_VERSION
     );
+  });
+
+  // -----------------------------------------------------------------------
+  // DEV-76: salt distribution on session.start
+  // -----------------------------------------------------------------------
+
+  test("session.start response includes salt + salt_version when active org is resolved", async () => {
+    const originalKey = process.env.PRIVACY_SALT_KEY;
+    process.env.PRIVACY_SALT_KEY = "test-salt-key";
+    try {
+      const sql = makeMockSql([], []);
+      const app = buildApp(sql, { session: { activeOrganizationId: "org-abc" } });
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(validEvent()),
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; salt?: string; salt_version?: number };
+      expect(body.ok).toBe(true);
+      expect(body.salt_version).toBe(1);
+      expect(body.salt).toMatch(/^[0-9a-f]{32}$/);
+    } finally {
+      if (originalKey === undefined) delete process.env.PRIVACY_SALT_KEY;
+      else process.env.PRIVACY_SALT_KEY = originalKey;
+    }
+  });
+
+  test("session.start salt is stable across requests for the same org", async () => {
+    const originalKey = process.env.PRIVACY_SALT_KEY;
+    process.env.PRIVACY_SALT_KEY = "test-salt-key";
+    try {
+      const app = buildApp(makeMockSql([], []), { session: { activeOrganizationId: "org-abc" } });
+
+      const a = (await (
+        await app.request("/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validEvent({ id: "evt-a", sessionId: "s-a" })),
+        })
+      ).json()) as { salt?: string };
+
+      const b = (await (
+        await app.request("/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validEvent({ id: "evt-b", sessionId: "s-b" })),
+        })
+      ).json()) as { salt?: string };
+
+      expect(a.salt).toBe(b.salt!);
+    } finally {
+      if (originalKey === undefined) delete process.env.PRIVACY_SALT_KEY;
+      else process.env.PRIVACY_SALT_KEY = originalKey;
+    }
+  });
+
+  test("session.start salt differs across orgs", async () => {
+    const originalKey = process.env.PRIVACY_SALT_KEY;
+    process.env.PRIVACY_SALT_KEY = "test-salt-key";
+    try {
+      const appA = buildApp(makeMockSql([], []), { session: { activeOrganizationId: "org-a" } });
+      const appB = buildApp(makeMockSql([], []), { session: { activeOrganizationId: "org-b" } });
+
+      const a = (await (
+        await appA.request("/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validEvent({ id: "evt-a", sessionId: "s-a" })),
+        })
+      ).json()) as { salt?: string };
+
+      const b = (await (
+        await appB.request("/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(validEvent({ id: "evt-b", sessionId: "s-b" })),
+        })
+      ).json()) as { salt?: string };
+
+      expect(a.salt).not.toBe(b.salt);
+    } finally {
+      if (originalKey === undefined) delete process.env.PRIVACY_SALT_KEY;
+      else process.env.PRIVACY_SALT_KEY = originalKey;
+    }
+  });
+
+  test("non-session.start events do not return a salt", async () => {
+    const sql = makeMockSql([{ status: "active" }], []);
+    const app = buildApp(sql, { session: { activeOrganizationId: "org-abc" } });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validEvent({ id: "evt-2", eventType: "prompt.submit" })),
+    });
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.salt).toBeUndefined();
+    expect(body.salt_version).toBeUndefined();
+  });
+
+  test("session.start with no resolvable org omits salt fields", async () => {
+    const sql = makeMockSql([], []);
+    const app = buildApp(sql); // no session set → no activeOrganizationId
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validEvent()),
+    });
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.ok).toBe(true);
+    expect(body.salt).toBeUndefined();
+    expect(body.salt_version).toBeUndefined();
+  });
+
+  test("strips a `salt` field from event.payload before insertEvent (defense-in-depth)", async () => {
+    const sql = makeMockSql([], []);
+    const app = buildApp(sql, { session: { activeOrganizationId: "org-abc" } });
+
+    await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        validEvent({ payload: { salt: "leaked-salt-should-not-persist", salt_version: 1 } }),
+      ),
+    });
+
+    const persistedEvent = mockInsertEvent.mock.calls[0]?.[1] as { payload?: Record<string, unknown> } | undefined;
+    expect(persistedEvent?.payload).toBeDefined();
+    expect(persistedEvent!.payload).not.toHaveProperty("salt");
+    // salt_version is allowed to flow through (it's part of the wire contract once DEV-74 lands)
+    expect(persistedEvent!.payload!.salt_version).toBe(1);
   });
 
   test("calls insertEvent with the event", async () => {

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -21,6 +21,7 @@ import { autoLinkDeveloperToOrg, autoLinkUserToDeveloper, computeDeveloperId } f
 import { stripSensitivePayload } from "../utils/stripSensitiveFields";
 import { logEthicsEvent } from "../utils/ethicsAudit";
 import { evaluateFriction, cleanupFrictionSession } from "../services/frictionDetector";
+import { CURRENT_SALT_VERSION, deriveOrgSalt } from "../utils/orgSalt";
 
 const eventSchema = z.object({
   id: z.string().min(1).max(200),
@@ -248,7 +249,14 @@ export function eventsRoutes(sql: SQL) {
       : null;
     const shouldCreateOrReactivate = !existingSession || wasEnded || event.eventType === "session.start";
     if (shouldCreateOrReactivate) {
-      await createSession(sql, event.sessionId, event.developerId, event.projectPath, event.projectName, permissionMode, privacyMode);
+      await createSession(sql, event.sessionId, event.developerId, event.projectPath, event.projectName, permissionMode, privacyMode, CURRENT_SALT_VERSION);
+    }
+
+    // DEV-76: Defense-in-depth — never persist a `salt` value into events.payload.
+    // The plugin (DEV-74) MUST NOT include it; this scrub guards against
+    // accidental future regressions. salt_version IS allowed to flow through.
+    if (event.payload && typeof event.payload === "object" && "salt" in (event.payload as Record<string, unknown>)) {
+      delete (event.payload as Record<string, unknown>).salt;
     }
 
     // Log ethics event when privacy mode is activated
@@ -279,6 +287,17 @@ export function eventsRoutes(sql: SQL) {
       }
     }
 
+    // DEV-76: precompute the salt response for session.start so we can return
+    // it even when the event itself is a duplicate (plugin retries must still
+    // be able to pin the salt for the rest of the session). The salt is
+    // resolved from the API-key-owner's active org (or the cookie session
+    // for dashboard-driven flows) and never persisted.
+    const sessionCtx = c.get("session" as never) as { activeOrganizationId?: string } | undefined;
+    const sessionStartSalt =
+      event.eventType === "session.start" && sessionCtx?.activeOrganizationId
+        ? { salt: deriveOrgSalt(sessionCtx.activeOrganizationId), salt_version: CURRENT_SALT_VERSION }
+        : null;
+
     const { stored } = await insertEvent(sql, event);
 
     // Idempotency: if a previous request already stored this event id, treat
@@ -287,7 +306,7 @@ export function eventsRoutes(sql: SQL) {
     // Pre-insert side effects above (createSession, upsertDeveloper, ethics
     // privacy_mode_activated) are already idempotent in their own right.
     if (!stored) {
-      return c.json({ ok: true, duplicate: true });
+      return c.json({ ok: true, duplicate: true, ...(sessionStartSalt ?? {}) });
     }
 
     // Run shared post-insert handlers (broadcasts, compaction, snapshots, friction)
@@ -332,6 +351,14 @@ export function eventsRoutes(sql: SQL) {
           }
         }
       }
+    }
+
+    // DEV-76: hand the plugin the per-org salt + version on session.start.
+    // Salt is in-memory only — never persisted to events.payload, the
+    // session row, or any audit log. Computed before insertEvent so that
+    // duplicate (idempotent) retries also return it.
+    if (sessionStartSalt) {
+      return c.json({ ok: true, ...sessionStartSalt });
     }
 
     return c.json({ ok: true });

--- a/packages/backend/src/utils/__tests__/orgSalt.test.ts
+++ b/packages/backend/src/utils/__tests__/orgSalt.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CURRENT_SALT_VERSION, deriveOrgSalt } from "../orgSalt";
+
+// DEV-76: salt distribution invariants.
+//
+// Each test sets PRIVACY_SALT_KEY explicitly to keep the suite hermetic — the
+// fallback to BETTER_AUTH_SECRET (or the dev constant) is intentionally not
+// exercised here so a missing env in CI does not flake the assertions.
+
+describe("orgSalt", () => {
+  let originalSaltKey: string | undefined;
+
+  beforeEach(() => {
+    originalSaltKey = process.env.PRIVACY_SALT_KEY;
+    process.env.PRIVACY_SALT_KEY = "test-privacy-salt-key";
+  });
+
+  afterEach(() => {
+    if (originalSaltKey === undefined) delete process.env.PRIVACY_SALT_KEY;
+    else process.env.PRIVACY_SALT_KEY = originalSaltKey;
+  });
+
+  test("CURRENT_SALT_VERSION starts at 1", () => {
+    expect(CURRENT_SALT_VERSION).toBe(1);
+  });
+
+  test("returns a 32-char hex string", () => {
+    const salt = deriveOrgSalt("org-abc");
+    expect(salt).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("is deterministic for the same org id", () => {
+    const a = deriveOrgSalt("org-abc");
+    const b = deriveOrgSalt("org-abc");
+    expect(a).toBe(b);
+  });
+
+  test("different orgs produce different salts", () => {
+    const a = deriveOrgSalt("org-abc");
+    const b = deriveOrgSalt("org-xyz");
+    expect(a).not.toBe(b);
+  });
+
+  test("rotating the server secret changes the salt for the same org", () => {
+    const before = deriveOrgSalt("org-abc");
+    process.env.PRIVACY_SALT_KEY = "rotated-key";
+    const after = deriveOrgSalt("org-abc");
+    expect(after).not.toBe(before);
+  });
+});

--- a/packages/backend/src/utils/orgSalt.ts
+++ b/packages/backend/src/utils/orgSalt.ts
@@ -1,0 +1,65 @@
+import { createHmac } from "node:crypto";
+
+/**
+ * DEV-76: Per-organization salt distribution for plugin-side path hashing.
+ *
+ * The plugin (DEV-74) hashes file_path/pattern/path values before they hit
+ * the wire. To keep the same path stable across all sessions in an org —
+ * but unrelatable across orgs — the backend hands out a deterministic
+ * per-org salt, keyed by a server-side secret, on session.start.
+ *
+ * Invariants:
+ *   - Salt is HMAC_SHA256(serverSecret, organizationId), hex-truncated to 32 chars.
+ *     Deterministic per (server-secret, org), stable across backend restarts.
+ *   - Salt is NEVER persisted (no events.payload, no log lines, no audit row).
+ *     Only `salt_version` is persisted per session.
+ *   - Server secret is read from PRIVACY_SALT_KEY first, falling back to
+ *     BETTER_AUTH_SECRET (already required-non-default in production by
+ *     packages/backend/src/index.ts).
+ *
+ * Salt rotation (incrementing CURRENT_SALT_VERSION) is intentionally out of
+ * scope here — DEV-43 will own that.
+ */
+
+export const CURRENT_SALT_VERSION = 1;
+
+const SALT_HEX_LENGTH = 32;
+
+let warnedMissingDedicatedKey = false;
+
+function getServerSecret(): string {
+  const dedicated = process.env.PRIVACY_SALT_KEY;
+  if (dedicated && dedicated.length > 0) return dedicated;
+
+  const auth = process.env.BETTER_AUTH_SECRET;
+  if (auth && auth.length > 0) {
+    if (!warnedMissingDedicatedKey) {
+      console.warn(
+        "[orgSalt] PRIVACY_SALT_KEY is not set; falling back to BETTER_AUTH_SECRET. " +
+        "Set a dedicated PRIVACY_SALT_KEY before salt rotation work (DEV-43)."
+      );
+      warnedMissingDedicatedKey = true;
+    }
+    return auth;
+  }
+
+  // Dev fallback so local stacks without either env still boot. Production
+  // refuses to start with a default BETTER_AUTH_SECRET (see index.ts), so
+  // this branch is only reachable in dev/test.
+  return "devscope-dev-privacy-salt";
+}
+
+/**
+ * Derive the per-org salt that the plugin should use for value hashing.
+ *
+ * Returns 32 hex chars (128 bits, sufficient for non-reverse-mappable hashes
+ * given the input space and HMAC keying). Result is the salt itself; do not
+ * log, persist, or audit-log this value.
+ */
+export function deriveOrgSalt(organizationId: string): string {
+  const secret = getServerSecret();
+  return createHmac("sha256", secret)
+    .update(organizationId)
+    .digest("hex")
+    .slice(0, SALT_HEX_LENGTH);
+}


### PR DESCRIPTION
## Summary

Backend half of the option-1 wire fix sanctioned on DEV-72. The plugin (DEV-74, gated on this PR) hashes `file_path`/`pattern`/`path` values at emit time using an org-scoped salt and pins a `salt_version`; this PR hands that salt out on `session.start` and stamps the version on the session row.

- New `src/utils/orgSalt.ts`: `deriveOrgSalt(orgId)` = HMAC-SHA256(server-secret, orgId), truncated to 32 hex chars. Secret reads from `PRIVACY_SALT_KEY` first, falls back to `BETTER_AUTH_SECRET` (already required-non-default in prod).
- Migration `036_sessions_salt_version.sql`: `sessions.salt_version SMALLINT NOT NULL DEFAULT 1` (existing rows backfilled to 1).
- `POST /api/events` for `session.start` now returns `{ ok, salt, salt_version }` resolved from the API-key-owner's active org via the existing `requireApiKeyOrSession` middleware. Salt is also returned on idempotent duplicate retries.
- Defense-in-depth: any incoming `event.payload.salt` is stripped before `insertEvent` so a future plugin regression cannot leak the salt to `events.payload`.
- The privacy-mode gate at `packages/backend/src/db/patternQueries.ts:144-162` is intentionally left unchanged this release per CEO ruling on DEV-72 §3.

## Test plan

- [x] `bun test packages/backend/src/utils/__tests__/orgSalt.test.ts` — deterministic per-org, 32-hex shape, secret rotation
- [x] `bun test packages/backend/src/routes/__tests__/events.test.ts` — same-org stable salt, different-org distinct salt, non-session.start no-salt, missing-org fallback, defensive `payload.salt` scrub
- [x] `tsc --noEmit` clean for changed files (one new TS2493 line matches existing bun mock-typing pattern in this file)
- [ ] End-to-end smoke against a local backend with a fresh API key once DEV-74 lands the plugin side

🤖 Generated with [Claude Code](https://claude.com/claude-code)