### PR TITLE
QA test scaffolds: DEV-87 (identity-forgery) + DEV-86 (output identity-leak guardrail)

### DIFF
--- a/packages/backend/src/ai/workflows/__tests__/reportWorkflow.output-guardrail.test.ts
+++ b/packages/backend/src/ai/workflows/__tests__/reportWorkflow.output-guardrail.test.ts
@@ -1,0 +1,287 @@
+/**
+ * DEV-86 — Output-side identity-leak guardrail.
+ *
+ * Premise: the input-side guardrail (`assertNoDeveloperIdentities`) is already
+ * wired in front of every weekly-buyer LLM call (see
+ * `reportWorkflow.guardrail.test.ts`). Gap #2 from the [DEV-84 brief] is that
+ * we have no automated assertion that the LLM **output** rows persisted to
+ * `ai_insights`, `ai_reports`, and the pattern surfaces are themselves
+ * identity-free. A model that hallucinates a developer name into the
+ * generated narrative would slip past the input-side check.
+ *
+ * This file does NOT call the live model in CI (per the task constraints).
+ * Instead it:
+ *
+ *   1. **Golden fixture regression** — frozen, hand-written representative
+ *      output bodies for each AI surface (ai_insight title+narrative,
+ *      ai_report title+content_markdown, ai_pattern name+narrative). Each
+ *      fixture is run through `detectDeveloperIdentities` against a synthetic
+ *      team roster and MUST return zero hits. Failing means the fixture itself
+ *      was authored with an identity-leak — file a follow-up bug.
+ *
+ *   2. **Property test of the detector** — for a battery of synthetic
+ *      identity strings (emails, first names, 64-hex SHA-256 ids, apikey
+ *      tokens), embed each verbatim into a fake output body and assert the
+ *      detector flags it. This proves the guardrail we plan to apply on the
+ *      output side will actually catch a leak, and that any future change to
+ *      detector internals does not regress on these classes.
+ *
+ * Mission-gate: every assertion is an *absence* assertion (or, in the property
+ * case, an assertion that the detector *finds* a leak we deliberately
+ * injected). Nothing here requires a name to be present in any user-facing
+ * surface.
+ *
+ * If a fixture-driven assertion fails, that is evidence of an actual leak in
+ * the recorded output. Per the DEV-86 acceptance criteria, file a follow-up
+ * bug issue against the responsible engineer rather than patching the fixture.
+ */
+
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { dbStubs } from "../../../__test_helpers__/mockStubs";
+import {
+  detectDeveloperIdentities,
+  _resetMissionRosterCache,
+} from "../../grounding/missionGuardrail";
+
+// ---------------------------------------------------------------------------
+// Synthetic team — same shape as `reportWorkflow.guardrail.test.ts` so the
+// two guardrail tests share an interpretation of "identity".
+// ---------------------------------------------------------------------------
+
+const TEAM = [
+  {
+    id: "a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90",
+    name: "Alice Johnson",
+    email: "alice@acme.test",
+  },
+  {
+    id: "b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1",
+    name: "Bob Patel",
+    email: "bob@acme.test",
+  },
+  {
+    id: "c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2",
+    name: "Carol Lee",
+    email: "carol@acme.test",
+  },
+];
+
+// Module mock is required because `detectDeveloperIdentities` reads from `sql`
+// directly. We do not exercise reportWorkflow here — only the guardrail
+// helper — but mocking the db barrel keeps us aligned with the sibling test
+// file's pattern and avoids surprise imports.
+mock.module("../../../db", () => dbStubs());
+
+function createMockSql() {
+  const fn = (...args: unknown[]) => {
+    const parts = args[0] as TemplateStringsArray | undefined;
+    const joined = parts ? parts.join("") : "";
+    if (joined.includes("FROM developers")) {
+      return Promise.resolve(TEAM);
+    }
+    return Promise.resolve([]);
+  };
+  return Object.assign(fn, {
+    begin: async (cb: (tx: unknown) => Promise<void>) => {
+      await cb((..._a: unknown[]) => Promise.resolve([]));
+    },
+  }) as any;
+}
+
+// ---------------------------------------------------------------------------
+// Golden frozen fixtures — one per AI surface.
+//
+// Each fixture is the shape that would land in the persisted row's
+// user-facing fields (title + narrative/markdown). Numbers, project names,
+// tool names, and aggregate verbs are intentionally rich; identity-bearing
+// strings are intentionally absent. If a future model run produces an output
+// resembling these shapes that DOES include identity, the runtime guardrail
+// is responsible for rejecting it — these fixtures only assert that
+// identity-free outputs of this shape pass cleanly (no false positives) and
+// that the detector wiring is intact.
+// ---------------------------------------------------------------------------
+
+const AI_INSIGHT_FIXTURE = {
+  surface: "ai_insight" as const,
+  type: "trend" as const,
+  severity: "info" as const,
+  title: "Bash tool failure rate climbed 18% week-over-week",
+  narrative:
+    "Across the team this week, Bash exit-code-1 failures rose from a 24% " +
+    "rate to a 28% rate. The cluster is concentrated in the billing-service " +
+    "project, where retry loops on `npm install` account for most of the " +
+    "delta. Recommendation: review the project's CLAUDE.md for an explicit " +
+    "package-manager pin so subsequent sessions don't re-discover the same " +
+    "failure path.",
+  data_context: {
+    period: { start: "2026-04-27", end: "2026-05-03" },
+    failure_rate: { current: 0.28, previous: 0.24, delta: 0.04 },
+    cluster: "tool.fail Bash exit 1",
+    top_project: "billing-service",
+  },
+};
+
+const AI_REPORT_FIXTURE = {
+  surface: "ai_report" as const,
+  report_type: "weekly" as const,
+  title: "Weekly Buyer Report — Week of 2026-04-27",
+  content_markdown:
+    "## Velocity\n\n" +
+    "- Sessions: 142 (+20% vs prior week)\n" +
+    "- Prompts: 1,820 (+13%)\n" +
+    "- Tool calls: 3,420 (+15%)\n\n" +
+    "## Tooling health\n\n" +
+    "- Bash exit-1 cluster concentrated in billing-service (18 sessions).\n" +
+    "- Auth-service tool-failure rate 35%; review of authentication " +
+    "fixtures recommended.\n\n" +
+    "## Pattern adoption\n\n" +
+    "- The outline-then-implement pattern was used in 24 sessions and is " +
+    "trending up.\n" +
+    "- One anti-pattern (thrash-edits) accounted for 4 of the long-tail " +
+    "sessions.\n",
+  data_context: {
+    period: { start: "2026-04-27", end: "2026-05-03" },
+    project_breakdown: [
+      { project_name: "billing-service", sessions: 42 },
+      { project_name: "auth-service", sessions: 31 },
+      { project_name: "checkout-web", sessions: 28 },
+    ],
+  },
+};
+
+const AI_PATTERN_FIXTURE = {
+  surface: "ai_pattern" as const,
+  name: "outline-then-implement",
+  effectiveness: "effective" as const,
+  narrative:
+    "Sessions that begin with a short outline before any Edit or Write call " +
+    "complete in 23% fewer tool calls and have a 41% lower thrash-edit " +
+    "incidence than sessions that begin with an immediate Edit. The pattern " +
+    "is observed across the billing-service, auth-service, and checkout-web " +
+    "projects.",
+  details: {
+    uses: 24,
+    avg_tool_call_reduction_pct: 23,
+    thrash_edit_reduction_pct: 41,
+    sample_session_id: "7dac753a-5888-4824-846e-f6aba44ff39e",
+  },
+};
+
+const SURFACE_FIXTURES = [
+  AI_INSIGHT_FIXTURE,
+  AI_REPORT_FIXTURE,
+  AI_PATTERN_FIXTURE,
+] as const;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DEV-86 output guardrail: frozen fixtures are identity-free", () => {
+  beforeEach(() => {
+    _resetMissionRosterCache();
+  });
+
+  for (const fixture of SURFACE_FIXTURES) {
+    test(`${fixture.surface}: golden output passes detector with zero hits`, async () => {
+      const sql = createMockSql();
+
+      const hits = await detectDeveloperIdentities(sql, fixture);
+
+      // Mission-gate: an *absence* assertion. If this fails, the fixture
+      // contains an identity-bearing string — file a follow-up bug rather
+      // than editing the fixture to mask the leak.
+      expect(hits).toEqual([]);
+
+      // Belt-and-braces serialization-level checks so a future detector
+      // refactor that loosens any one rule still leaves these surface-level
+      // invariants enforced.
+      const serialized = JSON.stringify(fixture);
+      for (const dev of TEAM) {
+        expect(serialized).not.toContain(dev.email);
+        expect(serialized).not.toContain(dev.id);
+        const firstName = dev.name.split(/\s+/)[0];
+        expect(serialized).not.toContain(firstName);
+      }
+      expect(/\bapikey-[A-Za-z0-9_-]+/.test(serialized)).toBe(false);
+      expect(/[0-9a-fA-F]{16,}/.test(serialized)).toBe(false);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Property test: the detector flags every class of identity-bearing string
+// when it appears verbatim in an otherwise innocuous output body. This is
+// the dual of the fixture test — fixtures prove no false positives on safe
+// shapes; this proves no false negatives on leaky shapes.
+//
+// Constructed by taking a known-good fixture and substituting one identity
+// token into the free-form narrative field. A future detector change that
+// regresses on any class will turn these into red.
+// ---------------------------------------------------------------------------
+
+interface InjectionCase {
+  label: string;
+  // The synthetic identity string to inject into output text.
+  identity: string;
+  // The leak class we expect the detector to report.
+  expectedKind:
+    | "developer_email"
+    | "developer_name"
+    | "developer_id_hash"
+    | "api_key_token";
+}
+
+const INJECTION_CASES: InjectionCase[] = [
+  {
+    label: "developer email echoed verbatim",
+    identity: TEAM[0].email,
+    expectedKind: "developer_email",
+  },
+  {
+    label: "developer first name echoed verbatim",
+    identity: TEAM[1].name.split(/\s+/)[0],
+    expectedKind: "developer_name",
+  },
+  {
+    label: "developer SHA-256 id echoed verbatim",
+    identity: TEAM[2].id,
+    expectedKind: "developer_id_hash",
+  },
+  {
+    label: "better-auth apikey token echoed verbatim",
+    // `apikey-` prefix + base64-ish suffix, matches the runtime regex.
+    identity: "apikey-AbCdEf0123456789",
+    expectedKind: "api_key_token",
+  },
+];
+
+describe("DEV-86 output guardrail: property — detector flags injected identities", () => {
+  beforeEach(() => {
+    _resetMissionRosterCache();
+  });
+
+  for (const c of INJECTION_CASES) {
+    test(c.label, async () => {
+      const sql = createMockSql();
+
+      // Take a benign output and splice the identity into the narrative.
+      // We do this on a clone so the golden fixture stays untouched.
+      const leakyOutput = {
+        ...AI_INSIGHT_FIXTURE,
+        narrative:
+          AI_INSIGHT_FIXTURE.narrative +
+          ` (cross-referenced with ${c.identity} in the source aggregate)`,
+      };
+
+      const hits = await detectDeveloperIdentities(sql, leakyOutput);
+
+      // Mission-gate phrasing: assert the detector *would have caught* a
+      // leak if one occurred. This does not require the leak text in any
+      // production surface — only that the guard layer is present and
+      // sensitive to this class of identity.
+      expect(hits.length).toBeGreaterThan(0);
+      expect(hits.map((h) => h.kind)).toContain(c.expectedKind);
+    });
+  }
+});

--- a/packages/backend/src/routes/__tests__/events.identity.test.ts
+++ b/packages/backend/src/routes/__tests__/events.identity.test.ts
@@ -1,0 +1,487 @@
+/**
+ * QA test scaffold — DEV-87 (gap #3 from DEV-84 brief)
+ *
+ * Purpose: document, in CI, two identity-trust gaps in POST /api/events:
+ *
+ *   1. Identity forgery: the route trusts whatever `developerId` the plugin
+ *      declares in the body. There is no check that
+ *      `developerId === SHA256(authUser.email)` for the API key owner. A
+ *      plugin (or any holder of a valid API key) can post events under any
+ *      developerId of their choosing.
+ *
+ *   2. Dual-namespace divergence: the Bash hook path (POST /api/events) trusts
+ *      the plugin's `SHA256(git config user.email)`; the HTTP hook path (POST
+ *      /api/events/hook) recomputes `SHA256(authUser.email)` server-side. When
+ *      a single human's `git config user.email` differs from their auth account
+ *      email, the same human produces two distinct developer rows — one per
+ *      ingestion path — with no convergence at query time.
+ *
+ * This file is a route-handler test, not an integration test. It runs against
+ * the in-process Hono app with mocked db/services, mirroring the pattern used
+ * in events.test.ts. The CTO's brief notes that real-Postgres CI is on the
+ * DEV-83 onboarding loop; once that lands, the convergence assertion can be
+ * tightened against a real schema. For now, we capture the calls that would
+ * have hit the DB and assert on those — that is enough to document the gap.
+ *
+ * Per DEV-87 acceptance: this test is expected to fail RED on `main`. The
+ * issue closes when this scaffold is committed; the underlying behavior is
+ * tracked in a follow-up bug filed against the Coder/CTO.
+ *
+ * Mission-gate note: this scaffold deliberately avoids any per-developer
+ * comparison/leaderboard surface, and never queries `developerName` outside
+ * the org it belongs to. It only asserts identity boundaries on the
+ * ingestion route.
+ */
+
+import { describe, expect, test, mock, beforeEach } from "bun:test";
+import { Hono } from "hono";
+import {
+  dbStubs,
+  wsHandlerStubs,
+  developerLinkStubs,
+  stripSensitiveFieldsStubs,
+} from "../../__test_helpers__/mockStubs";
+
+// ---------------------------------------------------------------------------
+// Mocks -- must be set up BEFORE importing the module under test.
+// Same shape as events.test.ts; we re-declare here so this file can run in
+// isolation (`bun test events.identity.test.ts`).
+// ---------------------------------------------------------------------------
+
+const mockUpsertDeveloper = mock(() => Promise.resolve());
+const mockCreateSession = mock(() => Promise.resolve());
+const mockEndSession = mock(() => Promise.resolve());
+const mockInsertEvent = mock(() => Promise.resolve({ stored: true }));
+const mockGetRecentEvents = mock(() => Promise.resolve([] as any[]));
+const mockCheckAlertThresholds = mock(() => Promise.resolve(null as any));
+
+mock.module("../../db", () =>
+  dbStubs({
+    upsertDeveloper: mockUpsertDeveloper,
+    createSession: mockCreateSession,
+    endSession: mockEndSession,
+    insertEvent: mockInsertEvent,
+    getRecentEvents: mockGetRecentEvents,
+    checkAlertThresholds: mockCheckAlertThresholds,
+  }),
+);
+
+const mockBroadcastToOrg = mock(() => {});
+mock.module("../../ws/handler", () =>
+  wsHandlerStubs({ broadcastToOrg: mockBroadcastToOrg }),
+);
+
+const mockAutoLinkDeveloperToOrg = mock(() => Promise.resolve());
+const mockAutoLinkUserToDeveloper = mock(() => Promise.resolve());
+
+mock.module("../../services/developerLink", () =>
+  developerLinkStubs({
+    autoLinkDeveloperToOrg: mockAutoLinkDeveloperToOrg,
+    autoLinkUserToDeveloper: mockAutoLinkUserToDeveloper,
+  }),
+);
+
+mock.module("../../utils/stripSensitiveFields", () =>
+  stripSensitiveFieldsStubs(),
+);
+
+mock.module("../../services/frictionDetector", () => ({
+  evaluateFriction: mock(() => null),
+  cleanupFrictionSession: mock(() => {}),
+}));
+
+mock.module("../../utils/ethicsAudit", () => ({
+  logEthicsEvent: mock(() => {}),
+}));
+
+// Import AFTER mocks are registered.
+const { eventsRoutes } = await import("../events");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Real SHA256(email) — same derivation used by both ingestion paths. */
+function sha256Email(email: string): string {
+  const normalized = email.toLowerCase().trim();
+  const hash = new Bun.CryptoHasher("sha256");
+  hash.update(normalized);
+  return hash.digest("hex");
+}
+
+/**
+ * Mock SQL tagged-template that responds to:
+ *   - `SELECT status FROM sessions ...`        → sessionRows
+ *   - `SELECT organization_id FROM organization_developer ...` → orgRows
+ *
+ * Other queries fall through to [].
+ */
+function makeMockSql(sessionRows: unknown[] = [], orgRows: unknown[] = []) {
+  let sRows = sessionRows;
+  let oRows = orgRows;
+
+  const fn = mock((strings: TemplateStringsArray, ..._values: unknown[]) => {
+    const query = strings.join("?");
+    if (query.includes("sessions")) return Promise.resolve(sRows);
+    if (query.includes("organization_developer")) return Promise.resolve(oRows);
+    return Promise.resolve([]);
+  });
+
+  (fn as any)._setSessionRows = (r: unknown[]) => {
+    sRows = r;
+  };
+  (fn as any)._setOrgRows = (r: unknown[]) => {
+    oRows = r;
+  };
+
+  return fn as typeof fn & {
+    _setSessionRows: (r: unknown[]) => void;
+    _setOrgRows: (r: unknown[]) => void;
+  };
+}
+
+function buildApp(
+  sql: any,
+  opts: {
+    apiKeyUserId?: string;
+    orgDeveloperIds?: string[];
+    user?: { id?: string; name?: string; email?: string };
+  } = {},
+) {
+  const app = new Hono();
+  app.use("/*", async (c, next) => {
+    if (opts.apiKeyUserId !== undefined) {
+      c.set("apiKeyUserId" as never, opts.apiKeyUserId as never);
+    }
+    if (opts.orgDeveloperIds !== undefined) {
+      c.set("orgDeveloperIds" as never, opts.orgDeveloperIds as never);
+    }
+    if (opts.user !== undefined) {
+      c.set("user" as never, opts.user as never);
+    }
+    await next();
+  });
+  app.route("/", eventsRoutes(sql));
+  return app;
+}
+
+function bodyForPostEvents(developerId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    id: "evt-identity-1",
+    timestamp: "2026-05-08T12:00:00Z",
+    sessionId: "sess-identity-1",
+    developerId,
+    developerName: "Plugin-Declared Name",
+    developerEmail: "plugin@declared.example",
+    projectPath: "/home/x/proj",
+    projectName: "proj",
+    eventType: "session.start",
+    payload: {},
+    ...overrides,
+  };
+}
+
+function resetAllMocks() {
+  mockUpsertDeveloper.mockReset();
+  mockUpsertDeveloper.mockImplementation(() => Promise.resolve());
+  mockCreateSession.mockReset();
+  mockCreateSession.mockImplementation(() => Promise.resolve());
+  mockEndSession.mockReset();
+  mockEndSession.mockImplementation(() => Promise.resolve());
+  mockInsertEvent.mockReset();
+  mockInsertEvent.mockImplementation(() => Promise.resolve({ stored: true }));
+  mockCheckAlertThresholds.mockReset();
+  mockCheckAlertThresholds.mockImplementation(() => Promise.resolve(null));
+  mockBroadcastToOrg.mockReset();
+  mockAutoLinkDeveloperToOrg.mockReset();
+  mockAutoLinkDeveloperToOrg.mockImplementation(() => Promise.resolve());
+  mockAutoLinkUserToDeveloper.mockReset();
+  mockAutoLinkUserToDeveloper.mockImplementation(() => Promise.resolve());
+}
+
+// ---------------------------------------------------------------------------
+// Fixture: two API-key owners.
+//   userA — owns the API key being used in the request.
+//   userB — a different human in the same org.
+// Their canonical developerIds are SHA256(email), the value the /hook path
+// would compute server-side.
+// ---------------------------------------------------------------------------
+
+const USER_A = {
+  authUserId: "user-A-id",
+  email: "alice@example.com",
+  name: "Alice",
+};
+const USER_B = {
+  authUserId: "user-B-id",
+  email: "bob@example.com",
+  name: "Bob",
+};
+const ALICE_DEV_ID = sha256Email(USER_A.email); // canonical for Alice
+const BOB_DEV_ID = sha256Email(USER_B.email); // canonical for Bob
+const ARBITRARY_DEV_ID = "deadbeef".repeat(8); // 64 hex chars, no email basis
+
+// ---------------------------------------------------------------------------
+// Identity-forgery matrix on POST /api/events
+//
+// Matrix dimensions: (apiKeyUserId, declared developerId).
+// Cases:
+//   matched         — apiKey=A, declared=SHA256(A.email)
+//   mismatched      — apiKey=A, declared=SHA256(B.email)  [B in different org]
+//   sameOrgForge    — apiKey=A, declared=SHA256(B.email)  [B in A's org]
+//   arbitrary       — apiKey=A, declared=arbitrary 64-hex string
+//   anon            — no apiKey, declared=arbitrary value (any caller can claim any id)
+//   expired         — simulated by absent apiKeyUserId + declared SHA256(B.email)
+//
+// Acceptance rule (per DEV-84 brief gap #3):
+//   "Mismatched tuples are rejected OR strictly auto-linked under documented
+//    rules."
+//
+// Today's behavior on `main`:
+//   - matched, mismatched, sameOrgForge, arbitrary: route ACCEPTS and stores
+//     the declared developerId verbatim. Only `matched` is correct; the others
+//     are forgery vectors.
+//   - anon: route ACCEPTS without auth.
+//   - expired: indistinguishable from anon at the route level (auth middleware
+//     should have rejected upstream; we assert the route's behavior on the
+//     downstream case where the middleware did not strip the body).
+//
+// Therefore every non-matched row is expected to FAIL RED until the route
+// either (a) rejects mismatched developerIds, or (b) overwrites the declared
+// id with the canonical SHA256(authUser.email) before persisting.
+// ---------------------------------------------------------------------------
+
+type ForgeryCase = {
+  name: string;
+  apiKeyUserId: string | undefined;
+  authUser: { id: string; name: string; email: string } | undefined;
+  declaredDeveloperId: string;
+  /** Canonical developerId we expect after route normalization, if any. */
+  canonicalDeveloperId: string | null;
+  /**
+   * Documented expectation per DEV-84 brief.
+   *   "reject"    — route should respond non-2xx OR not call insertEvent.
+   *   "normalize" — route should call insertEvent with canonicalDeveloperId,
+   *                 not the declared one.
+   *   "accept"    — declared id is canonical; insert is correct.
+   */
+  expectation: "reject" | "normalize" | "accept";
+};
+
+const forgeryMatrix: ForgeryCase[] = [
+  {
+    name: "matched: apiKey=A, declared=SHA256(A.email)",
+    apiKeyUserId: USER_A.authUserId,
+    authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
+    declaredDeveloperId: ALICE_DEV_ID,
+    canonicalDeveloperId: ALICE_DEV_ID,
+    expectation: "accept",
+  },
+  {
+    name: "mismatched: apiKey=A, declared=SHA256(B.email) [different org]",
+    apiKeyUserId: USER_A.authUserId,
+    authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
+    declaredDeveloperId: BOB_DEV_ID,
+    canonicalDeveloperId: ALICE_DEV_ID,
+    expectation: "reject",
+  },
+  {
+    name: "sameOrgForge: apiKey=A, declared=SHA256(B.email) [B is in A's org]",
+    apiKeyUserId: USER_A.authUserId,
+    authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
+    declaredDeveloperId: BOB_DEV_ID,
+    canonicalDeveloperId: ALICE_DEV_ID,
+    // Same-org membership does not authorize cross-identity event posting.
+    // Either reject or normalize to A — never silently store as B.
+    expectation: "reject",
+  },
+  {
+    name: "arbitrary: apiKey=A, declared=opaque hex (no email basis)",
+    apiKeyUserId: USER_A.authUserId,
+    authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
+    declaredDeveloperId: ARBITRARY_DEV_ID,
+    canonicalDeveloperId: ALICE_DEV_ID,
+    expectation: "reject",
+  },
+  {
+    name: "anon: no apiKey, declared=SHA256(B.email)",
+    apiKeyUserId: undefined,
+    authUser: undefined,
+    declaredDeveloperId: BOB_DEV_ID,
+    canonicalDeveloperId: null,
+    // Without an authenticated identity, the route has no basis to attribute
+    // the event to anyone. Should reject.
+    expectation: "reject",
+  },
+  {
+    name: "expired: API key auth missing, declared=SHA256(B.email)",
+    apiKeyUserId: undefined,
+    authUser: undefined,
+    declaredDeveloperId: BOB_DEV_ID,
+    canonicalDeveloperId: null,
+    expectation: "reject",
+  },
+];
+
+describe("POST /events — identity-forgery guards (DEV-87 gap #3)", () => {
+  beforeEach(resetAllMocks);
+
+  for (const c of forgeryMatrix) {
+    test(c.name, async () => {
+      const sql = makeMockSql([], [{ organization_id: "org-shared" }]);
+      const app = buildApp(sql, {
+        apiKeyUserId: c.apiKeyUserId,
+        user: c.authUser,
+      });
+
+      const res = await app.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(bodyForPostEvents(c.declaredDeveloperId)),
+      });
+
+      if (c.expectation === "accept") {
+        // Canonical case: 2xx, persisted under the canonical id.
+        expect(res.status).toBe(200);
+        expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+        const insertedEvent = (mockInsertEvent.mock.calls[0] as any[])[1];
+        expect(insertedEvent.developerId).toBe(c.canonicalDeveloperId);
+        return;
+      }
+
+      if (c.expectation === "reject") {
+        // Either the route returns a non-2xx, or it never calls insertEvent.
+        // Both forms count as "rejected" for this guard. Today's `main` does
+        // neither — it returns 200 and persists the forged id.
+        const rejected =
+          res.status >= 400 || mockInsertEvent.mock.calls.length === 0;
+        expect(rejected).toBe(true);
+        // Belt-and-braces: if anything was inserted, it must NOT carry the
+        // declared (forged) developerId.
+        if (mockInsertEvent.mock.calls.length > 0) {
+          const insertedEvent = (mockInsertEvent.mock.calls[0] as any[])[1];
+          expect(insertedEvent.developerId).not.toBe(c.declaredDeveloperId);
+        }
+        return;
+      }
+
+      // c.expectation === "normalize": route must overwrite the declared id
+      // with the canonical id before persisting.
+      expect(res.status).toBe(200);
+      expect(mockInsertEvent).toHaveBeenCalledTimes(1);
+      const insertedEvent = (mockInsertEvent.mock.calls[0] as any[])[1];
+      expect(insertedEvent.developerId).toBe(c.canonicalDeveloperId);
+      expect(insertedEvent.developerId).not.toBe(c.declaredDeveloperId);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Dual-namespace convergence on POST /api/events vs POST /api/events/hook
+//
+// Scenarios:
+//   sameEmail        — plugin git email == auth account email. Both paths
+//                      should produce the same canonical developerId.
+//   pluginEmailDrift — plugin git email differs from auth account email.
+//                      Each path computes a different SHA256, so the same
+//                      human is split across two developer rows. The brief
+//                      requires either rejection at insert OR strict
+//                      normalization at insert OR documented convergence at
+//                      query time.
+//
+// We assert the simplest, route-level guarantee: for the same human (same
+// apiKeyUserId), the developerId persisted by both ingestion paths MUST be
+// identical. If the plugin path stores SHA256(plugin_email) and the hook path
+// stores SHA256(auth_email), the assertion fails — that's the gap.
+// ---------------------------------------------------------------------------
+
+type ConvergenceCase = {
+  name: string;
+  pluginGitEmail: string; // what the plugin computed and put in the body
+  authEmail: string; // what auth_user.email resolves to for the API key owner
+};
+
+const convergenceMatrix: ConvergenceCase[] = [
+  {
+    name: "sameEmail: plugin git email matches auth email",
+    pluginGitEmail: USER_A.email,
+    authEmail: USER_A.email,
+  },
+  {
+    name: "pluginEmailDrift: plugin git email differs from auth email",
+    pluginGitEmail: "alice@personal.example", // e.g. personal git email
+    authEmail: USER_A.email, // alice@example.com on the SaaS account
+  },
+];
+
+describe("Dual-namespace convergence (DEV-87 gap #3)", () => {
+  beforeEach(resetAllMocks);
+
+  for (const c of convergenceMatrix) {
+    test(c.name, async () => {
+      // --- POST /api/events (Bash hook path: plugin declares developerId) ---
+      const sqlPlugin = makeMockSql([], [{ organization_id: "org-shared" }]);
+      const appPlugin = buildApp(sqlPlugin, {
+        apiKeyUserId: USER_A.authUserId,
+        user: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
+      });
+
+      const pluginDeclaredDevId = sha256Email(c.pluginGitEmail);
+
+      const resPlugin = await appPlugin.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(
+          bodyForPostEvents(pluginDeclaredDevId, {
+            id: "evt-plugin-1",
+            sessionId: "sess-plugin-1",
+            developerEmail: c.pluginGitEmail,
+          }),
+        ),
+      });
+      expect(resPlugin.status).toBeLessThan(500);
+      const pluginInsertCalls = mockInsertEvent.mock.calls.slice();
+      const pluginPersistedDevId =
+        pluginInsertCalls.length > 0
+          ? (pluginInsertCalls[0] as any[])[1]?.developerId
+          : null;
+
+      // --- POST /api/events/hook (HTTP hook path: server derives developerId) ---
+      resetAllMocks();
+      const sqlHook = makeMockSql([], [{ organization_id: "org-shared" }]);
+      const appHook = buildApp(sqlHook, {
+        apiKeyUserId: USER_A.authUserId,
+        user: { id: USER_A.authUserId, name: USER_A.name, email: c.authEmail },
+      });
+
+      const resHook = await appHook.request("/hook?event=notification", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: "sess-hook-1",
+          cwd: "/home/alice/proj",
+        }),
+      });
+      expect(resHook.status).toBeLessThan(500);
+      const hookInsertCalls = mockInsertEvent.mock.calls.slice();
+      const hookPersistedDevId =
+        hookInsertCalls.length > 0
+          ? (hookInsertCalls[0] as any[])[1]?.developerId
+          : null;
+
+      // Convergence assertion: same human, both paths → same developerId at
+      // insert. If neither path inserted (both rejected), that is also a
+      // valid documented outcome; we only fail when the two paths produced
+      // distinct ids.
+      if (pluginPersistedDevId !== null && hookPersistedDevId !== null) {
+        expect(pluginPersistedDevId).toBe(hookPersistedDevId);
+      } else {
+        // At least one path must have explicitly rejected — record that here
+        // so the failure mode is visible in the test report.
+        expect(
+          pluginPersistedDevId === null || hookPersistedDevId === null,
+        ).toBe(true);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Stacked branch carrying QA test scaffolds for two DEV-84 brief gaps. Both add tests only — no production code changes.

### Commits

- **DEV-48** (b3b2aab, 2f38441) — doc-gap helper + weekly-buyer prompt slot fill (carried forward from prior stacking)
- **[DEV-87](/DEV/issues/DEV-87)** (51641c8) — `events.identity.test.ts` scaffold (RED on `main`, gap #3): identity forgery + dual-namespace divergence on `POST /api/events`. Failing rows are intentional — they document the gap.
- **[DEV-86](/DEV/issues/DEV-86)** (9e9bf07) — `reportWorkflow.output-guardrail.test.ts` (gap #2): LLM-output identity-leak guardrail. 7 tests, all green.

## DEV-86 detail

- 3 frozen golden-fixture assertions (one per AI surface — `ai_insight`, `ai_report`, `ai_pattern`): runs `detectDeveloperIdentities` against a synthetic team roster and expects zero hits, plus serialization-level absence checks for email, name, 64-hex SHA, and `apikey-*`.
- 4 property cases injecting each leak class verbatim into a benign output — asserts the detector flags it. Guards against detector regressions.
- Mission-gate: every assertion is *absence-of-identity*. No live model calls, no real Postgres.
- If a fixture-driven assertion ever fails, that's evidence of a real leak — file a follow-up bug rather than patch the fixture (per DEV-86 acceptance).

## Test plan

- [x] DEV-86 file in isolation: `bun test src/ai/workflows/__tests__/reportWorkflow.output-guardrail.test.ts` → 7 pass / 0 fail / 44 expect()
- [x] Full backend `bun test`: my file adds 7 passes; remaining failures (DEV-87 RED scaffold, `flushEthicsAudit` mock-leak) are pre-existing/intentional
- [x] DEV-87 file in isolation: documented RED on main per the gap-test design

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation gaps subsection to weekly buyer reports, identifying frequently-referenced areas with insufficient documentation in Friday narratives.

* **Security Improvements**
  * Enhanced protections against identity leaks in AI-generated content.
  * Strengthened identity verification for API event tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->