### PR TITLE
DEV-88: QA test scaffold for plugin↔backend wire-contract enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The plugin↔backend wire-contract test
+      # (packages/backend/src/routes/__tests__/events.contract.test.ts) loads
+      # fixtures from the side-by-side devscope-plugin checkout. Mirrors the
+      # symmetric pattern in DowLucas/devscope-plugin's smoke job, which
+      # cross-checks out devscope.
+      - name: Checkout devscope-plugin (sibling — wire-contract fixtures)
+        uses: actions/checkout@v4
+        with:
+          repository: DowLucas/devscope-plugin
+          ref: main
+          path: devscope-plugin
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/packages/backend/src/routes/__tests__/events.contract.test.ts
+++ b/packages/backend/src/routes/__tests__/events.contract.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Plugin↔backend wire-contract test (DEV-88, gap #4 from DEV-84 brief).
+ *
+ * Loads each fixture from the side-by-side plugin checkout
+ * (`devscope-plugin/tests/smoke/fixtures/*.json`), transforms it to the
+ * camelCase wire-shape DevscopeEvent the plugin's hook scripts emit, and
+ * validates against the strict per-EventType discriminator schema in
+ * `../../utils/eventSchemas`.
+ *
+ * Coverage:
+ *   - 7 valid fixtures parse cleanly (the EventTypes the plugin currently
+ *     emits via smoke). Backend strict policy: any unknown payload key, any
+ *     missing required field, or any unknown eventType is rejected.
+ *   - 1 deliberately malformed payload per shape (e.g. session.start missing
+ *     `startType`, prompt.submit with wrong-typed `promptLength`) is rejected.
+ *   - The discriminated union also rejects an unknown `eventType` value.
+ *
+ * Plugin-side smoke (`devscope-plugin/tests/smoke/run.sh`) intentionally
+ * remains lenient — cross-repo enforcement is a follow-up.
+ */
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import {
+  payloadSchemasByEventType,
+  strictEventSchema,
+  type EventTypeKey,
+} from "../../utils/eventSchemas";
+
+// ---------------------------------------------------------------------------
+// Fixture discovery (cross-repo, side-by-side checkout)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk up from this test file looking for the side-by-side `devscope-plugin/`
+ * checkout. The CI lane on the plugin side already cross-checks out the
+ * server, so the inverse is fine for local + CI.
+ */
+function locatePluginFixturesDir(): string | null {
+  let dir = dirname(import.meta.path);
+  for (let i = 0; i < 10; i++) {
+    const candidate = join(dir, "devscope-plugin", "tests", "smoke", "fixtures");
+    if (existsSync(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+const fixturesDir = locatePluginFixturesDir();
+
+function readFixture(file: string): Record<string, unknown> {
+  if (!fixturesDir) {
+    throw new Error(
+      `devscope-plugin fixtures not found via side-by-side checkout (looked from ${import.meta.path})`,
+    );
+  }
+  return JSON.parse(readFileSync(resolve(fixturesDir, file), "utf-8"));
+}
+
+// ---------------------------------------------------------------------------
+// Plugin-script transformation mirrors
+// ---------------------------------------------------------------------------
+//
+// Each helper mirrors the relevant `devscope-plugin/scripts/*.sh` to produce
+// the wire-shape camelCase payload the backend actually receives. Kept inline
+// (not shared with production code) so a drift in the plugin's transform
+// surfaces as a contract-test diff rather than silently aligning.
+
+function envelope(eventType: EventTypeKey, payload: Record<string, unknown>) {
+  return {
+    id: "evt-contract-test",
+    timestamp: "2026-05-08T12:00:00Z",
+    sessionId: "smoke-session-0001",
+    developerId: "abc123def456",
+    developerName: "Contract Tester",
+    developerEmail: "qa@example.com",
+    projectPath: "/tmp/smoke-project",
+    projectName: "smoke-project",
+    eventType,
+    payload,
+  };
+}
+
+function transformSessionStart(raw: Record<string, unknown>) {
+  // Mirrors scripts/session-start.sh under DEVSCOPE_PRIVACY=standard, no git.
+  const payload: Record<string, unknown> = {
+    startType: (raw.source as string) ?? "startup",
+    permissionMode: (raw.permission_mode as string) ?? "default",
+    continued: false,
+    claudeSessionId: (raw.session_id as string) ?? "",
+    privacyMode: "standard",
+  };
+  if (raw.model) payload.model = raw.model;
+  return envelope("session.start", payload);
+}
+
+function transformSessionEnd(raw: Record<string, unknown>) {
+  // Mirrors scripts/session-end.sh — endReason from `reason`, no git/files.
+  return envelope("session.end", {
+    endReason: (raw.reason as string) ?? "other",
+  });
+}
+
+function transformPromptSubmit(raw: Record<string, unknown>) {
+  // Mirrors scripts/prompt-submit.sh under DEVSCOPE_PRIVACY=standard.
+  const prompt = (raw.prompt as string) ?? "";
+  return envelope("prompt.submit", {
+    promptLength: prompt.length,
+    isContinuation: Boolean(raw.is_continuation),
+    promptText: prompt,
+  });
+}
+
+function transformToolUse(raw: Record<string, unknown>) {
+  // Mirrors scripts/tool-use.sh under DEVSCOPE_PRIVACY=standard.
+  const payload: Record<string, unknown> = {
+    toolName: (raw.tool_name as string) ?? "unknown",
+  };
+  if (raw.tool_input != null) payload.toolInput = raw.tool_input;
+  return envelope("tool.start", payload);
+}
+
+function transformToolComplete(raw: Record<string, unknown>) {
+  // Mirrors scripts/tool-complete.sh under DEVSCOPE_PRIVACY=standard.
+  const payload: Record<string, unknown> = {
+    toolName: (raw.tool_name as string) ?? "unknown",
+    success: true,
+    duration: 0,
+    isInterrupt: Boolean(raw.is_interrupt),
+  };
+  if (raw.tool_input != null) payload.toolInput = raw.tool_input;
+  if (raw.tool_result != null) payload.toolResult = raw.tool_result;
+  return envelope("tool.complete", payload);
+}
+
+function transformResponseStop(raw: Record<string, unknown>) {
+  // Mirrors scripts/response-stop.sh under DEVSCOPE_PRIVACY=standard
+  // (no responseText in standard mode; only included under `open`).
+  const msg = (raw.last_assistant_message as string) ?? "";
+  return envelope("response.complete", {
+    responseLength: msg.length,
+  });
+}
+
+function transformNotification(raw: Record<string, unknown>) {
+  // Mirrors scripts/notification.sh.
+  return envelope("notification", {
+    notificationType: (raw.notification_type as string) ?? "info",
+    title: (raw.title as string) ?? "",
+    message: ((raw.message as string) ?? "").slice(0, 100),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("plugin↔backend wire contract (DEV-88)", () => {
+  test("fixture directory is reachable via side-by-side checkout", () => {
+    expect(fixturesDir).not.toBeNull();
+  });
+
+  // Each entry: [fixture file, plugin transform mirror, expected EventType].
+  const fixtureCases: Array<{
+    file: string;
+    transform: (raw: Record<string, unknown>) => ReturnType<typeof envelope>;
+    eventType: EventTypeKey;
+  }> = [
+    { file: "session-start.json", transform: transformSessionStart, eventType: "session.start" },
+    { file: "session-end.json", transform: transformSessionEnd, eventType: "session.end" },
+    { file: "prompt-submit.json", transform: transformPromptSubmit, eventType: "prompt.submit" },
+    { file: "tool-use.json", transform: transformToolUse, eventType: "tool.start" },
+    { file: "tool-complete.json", transform: transformToolComplete, eventType: "tool.complete" },
+    { file: "response-stop.json", transform: transformResponseStop, eventType: "response.complete" },
+    { file: "notification.json", transform: transformNotification, eventType: "notification" },
+  ];
+
+  for (const { file, transform, eventType } of fixtureCases) {
+    test(`${file} → ${eventType} parses against strict schema`, () => {
+      const raw = readFixture(file);
+      const event = transform(raw);
+      const result = strictEventSchema.safeParse(event);
+      if (!result.success) {
+        // Surface useful diff for debugging when a fixture/schema drifts.
+        // eslint-disable-next-line no-console
+        console.error(`[contract] ${file} failed:`, result.error.issues);
+      }
+      expect(result.success).toBe(true);
+      expect(result.data?.eventType).toBe(eventType);
+    });
+  }
+
+  test("every EventType in shared has a payload schema", () => {
+    // Snapshot the keys so adding a new EventType without a schema fails CI.
+    const known = Object.keys(payloadSchemasByEventType).sort();
+    expect(known).toEqual(
+      [
+        "agent.start",
+        "agent.stop",
+        "compact.complete",
+        "compact.pending",
+        "config.change",
+        "elicitation.request",
+        "elicitation.response",
+        "instructions.loaded",
+        "notification",
+        "permission.request",
+        "prompt.submit",
+        "response.complete",
+        "session.end",
+        "session.start",
+        "task.completed",
+        "teammate.idle",
+        "tool.complete",
+        "tool.fail",
+        "tool.start",
+        "worktree.create",
+        "worktree.remove",
+      ].sort(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Negative cases: deliberately malformed payloads must fail
+  // -------------------------------------------------------------------------
+
+  test("session.start missing startType is rejected", () => {
+    const broken = envelope("session.start", {
+      // startType intentionally omitted
+      permissionMode: "default",
+      continued: false,
+      privacyMode: "standard",
+    });
+    const result = strictEventSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  test("prompt.submit with wrong-typed promptLength is rejected", () => {
+    const broken = envelope("prompt.submit", {
+      promptLength: "not-a-number",
+      isContinuation: false,
+    });
+    const result = strictEventSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  test("strict mode rejects unknown payload keys", () => {
+    const broken = envelope("notification", {
+      notificationType: "info",
+      title: "hi",
+      message: "ok",
+      // Unknown extra key — strict() must reject so wire drift surfaces.
+      definitelyNotInWireContract: true,
+    });
+    const result = strictEventSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+
+  test("unknown eventType is rejected", () => {
+    const broken = {
+      ...envelope("notification", {
+        notificationType: "info",
+        title: "hi",
+        message: "ok",
+      }),
+      eventType: "session.bogus",
+    };
+    const result = strictEventSchema.safeParse(broken);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/backend/src/utils/eventSchemas.ts
+++ b/packages/backend/src/utils/eventSchemas.ts
@@ -1,0 +1,332 @@
+/**
+ * Per-EventType payload schemas — wire-contract enforcement at the boundary.
+ *
+ * The /api/events route currently accepts `payload: z.record(z.unknown())`,
+ * meaning the 18 payload variants in `@devscope/shared` are unenforced past
+ * the envelope. This module defines a strict, per-`EventType` discriminator
+ * union the route can plug in to reject unknown variants and unknown keys.
+ *
+ * Policy (DEV-88, CTO-approved):
+ *   - Backend is **strict**: unknown EventType values, unknown payload keys,
+ *     and missing required fields all fail validation.
+ *   - Plugin remains lenient (logs and sends anyway; cross-repo enforcement
+ *     is a follow-up).
+ *
+ * Wire-shape notes (intentional drift the schema must accept):
+ *   - `tool.complete` carries `toolResult` on the wire, even though the
+ *     `ToolEventPayload` TS type does not list it (see
+ *     `devscope-plugin/scripts/tool-complete.sh`). Adding it to the schema
+ *     documents reality and is not a wire-contract change.
+ *   - `salt_version` may be appended by `send-event.sh` in private mode
+ *     for any event type. Schemas accept it as an optional number alongside
+ *     the typed fields.
+ */
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Shared building blocks
+// ---------------------------------------------------------------------------
+
+const tokenUsageSchema = z
+  .object({
+    inputTokens: z.number(),
+    outputTokens: z.number(),
+    cacheCreationTokens: z.number(),
+    cacheReadTokens: z.number(),
+  })
+  .strict();
+
+const claudeMdFileSchema = z
+  .object({
+    path: z.string(),
+    hash: z.string(),
+    size: z.number(),
+    content: z.string().optional(),
+  })
+  .strict();
+
+const instructionsFileSchema = z
+  .object({
+    path: z.string(),
+    hash: z.string(),
+    size: z.number(),
+    content: z.string().optional(),
+    type: z.enum(["claude_md", "rule"]),
+  })
+  .strict();
+
+/** `salt_version` may be tacked onto any payload by send-event.sh (private mode). */
+const privacyAnnotations = {
+  salt_version: z.number().optional(),
+} as const;
+
+// ---------------------------------------------------------------------------
+// Per-event payload schemas
+// ---------------------------------------------------------------------------
+
+const sessionStartPayloadSchema = z
+  .object({
+    startType: z.string(),
+    permissionMode: z.string(),
+    privacyMode: z.string().optional(),
+    continued: z.boolean().optional(),
+    claudeSessionId: z.string().optional(),
+    model: z.string().optional(),
+    gitBranch: z.string().optional(),
+    gitCommit: z.string().optional(),
+    gitRemoteUrl: z.string().optional(),
+    claudeMdFiles: z.array(claudeMdFileSchema).optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const sessionEndPayloadSchema = z
+  .object({
+    endReason: z.string(),
+    duration: z.number().optional(),
+    filesChanged: z.array(z.string()).optional(),
+    gitBranch: z.string().optional(),
+    gitCommit: z.string().optional(),
+    tokenUsage: tokenUsageSchema.optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const promptSubmitPayloadSchema = z
+  .object({
+    promptLength: z.number(),
+    isContinuation: z.boolean(),
+    promptText: z.string().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const toolEventPayloadBase = {
+  toolName: z.string(),
+  toolSubcommand: z.string().optional(),
+  toolInput: z.record(z.unknown()).optional(),
+  duration: z.number().optional(),
+  success: z.boolean().optional(),
+  errorMessage: z.string().optional(),
+  isInterrupt: z.boolean().optional(),
+  agentId: z.string().nullable().optional(),
+  ...privacyAnnotations,
+} as const;
+
+const toolStartPayloadSchema = z.object(toolEventPayloadBase).strict();
+
+/**
+ * tool.complete additionally carries `toolResult` on the wire — see
+ * scripts/tool-complete.sh. Not in the shared TS type, but real on wire.
+ */
+const toolCompletePayloadSchema = z
+  .object({
+    ...toolEventPayloadBase,
+    toolResult: z.unknown().optional(),
+  })
+  .strict();
+
+const toolFailPayloadSchema = toolCompletePayloadSchema; // same shape
+
+const agentEventPayloadSchema = z
+  .object({
+    agentType: z.string(),
+    agentId: z.string(),
+    parentAgentId: z.string().nullable().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const responsePayloadSchema = z
+  .object({
+    responseLength: z.number().optional(),
+    toolsUsed: z.array(z.string()).optional(),
+    responseText: z.string().optional(),
+    tokenUsage: tokenUsageSchema.optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const notificationPayloadSchema = z
+  .object({
+    notificationType: z.string(),
+    title: z.string(),
+    message: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const preCompactPayloadSchema = z
+  .object({
+    trigger: z.string(),
+    hasCustomInstructions: z.boolean().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const taskCompletedPayloadSchema = z
+  .object({
+    taskId: z.string(),
+    taskSubject: z.string(),
+    taskDescription: z.string(),
+    teammateName: z.string(),
+    teamName: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const permissionRequestPayloadSchema = z
+  .object({
+    toolName: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const worktreeCreatePayloadSchema = z
+  .object({
+    worktreeName: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const worktreeRemovePayloadSchema = z
+  .object({
+    worktreePath: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const configChangePayloadSchema = z
+  .object({
+    source: z.string(),
+    filePath: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const postCompactPayloadSchema = z
+  .object({
+    summary: z.string().optional(),
+    tokensBefore: z.number().optional(),
+    tokensAfter: z.number().optional(),
+    reductionPercent: z.number().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const elicitationPayloadSchema = z
+  .object({
+    mcpServerName: z.string(),
+    message: z.string().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const elicitationResultPayloadSchema = z
+  .object({
+    mcpServerName: z.string(),
+    duration: z.number().optional(),
+    responded: z.boolean(),
+    response: z.string().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const instructionsLoadedPayloadSchema = z
+  .object({
+    files: z.array(instructionsFileSchema),
+    trigger: z.string(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+const teammateIdlePayloadSchema = z
+  .object({
+    teammateName: z.string(),
+    teamName: z.string(),
+    agentId: z.string().optional(),
+    idleReason: z.string().optional(),
+    ...privacyAnnotations,
+  })
+  .strict();
+
+// ---------------------------------------------------------------------------
+// Map keyed by EventType — single lookup point for the route + tests
+// ---------------------------------------------------------------------------
+
+export const payloadSchemasByEventType = {
+  "session.start": sessionStartPayloadSchema,
+  "session.end": sessionEndPayloadSchema,
+  "prompt.submit": promptSubmitPayloadSchema,
+  "tool.start": toolStartPayloadSchema,
+  "tool.complete": toolCompletePayloadSchema,
+  "tool.fail": toolFailPayloadSchema,
+  "agent.start": agentEventPayloadSchema,
+  "agent.stop": agentEventPayloadSchema,
+  "response.complete": responsePayloadSchema,
+  "notification": notificationPayloadSchema,
+  "compact.pending": preCompactPayloadSchema,
+  "task.completed": taskCompletedPayloadSchema,
+  "permission.request": permissionRequestPayloadSchema,
+  "worktree.create": worktreeCreatePayloadSchema,
+  "worktree.remove": worktreeRemovePayloadSchema,
+  "config.change": configChangePayloadSchema,
+  "compact.complete": postCompactPayloadSchema,
+  "elicitation.request": elicitationPayloadSchema,
+  "elicitation.response": elicitationResultPayloadSchema,
+  "instructions.loaded": instructionsLoadedPayloadSchema,
+  "teammate.idle": teammateIdlePayloadSchema,
+} as const;
+
+export type EventTypeKey = keyof typeof payloadSchemasByEventType;
+
+// ---------------------------------------------------------------------------
+// Envelope schema — strict event-level fields + dispatched payload
+// ---------------------------------------------------------------------------
+
+const eventEnvelopeBase = z.object({
+  id: z.string().min(1).max(200),
+  timestamp: z.string().min(1).max(50),
+  sessionId: z.string().min(1).max(200),
+  developerId: z.string().min(1).max(200),
+  developerName: z.string().min(1).max(200),
+  developerEmail: z.string().max(500).optional().default(""),
+  projectPath: z.string().max(1000),
+  projectName: z.string().max(200),
+});
+
+/**
+ * Discriminated event schema: validates envelope + per-EventType payload.
+ *
+ * Use this in the route handler in place of `z.record(z.unknown())` to enforce
+ * the wire contract at the API boundary.
+ */
+export const strictEventSchema = eventEnvelopeBase
+  .extend({
+    eventType: z.enum(
+      Object.keys(payloadSchemasByEventType) as [EventTypeKey, ...EventTypeKey[]],
+    ),
+    payload: z.record(z.unknown()),
+  })
+  .superRefine((event, ctx) => {
+    const schema = payloadSchemasByEventType[event.eventType as EventTypeKey];
+    if (!schema) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["eventType"],
+        message: `Unknown eventType: ${event.eventType}`,
+      });
+      return;
+    }
+    const result = schema.safeParse(event.payload);
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        ctx.addIssue({
+          ...issue,
+          path: ["payload", ...(issue.path ?? [])],
+        });
+      }
+    }
+  });
+
+export type StrictEvent = z.infer<typeof strictEventSchema>;


### PR DESCRIPTION
## Summary

Lands the [DEV-88](/DEV/issues/DEV-88) QA scaffold authored by the QA agent. Enforces the per-`EventType` payload contract at the backend boundary via Zod + a contract test that exercises every plugin fixture.

- `packages/backend/src/utils/eventSchemas.ts` — `payloadSchemasByEventType` (21 keys / 18 distinct shapes, all `.strict()`) plus `strictEventSchema` envelope with `superRefine` dispatch by `eventType`.
- `packages/backend/src/routes/__tests__/events.contract.test.ts` — loads each fixture from the side-by-side `devscope-plugin/tests/smoke/fixtures/`, mirrors the per-script transform to wire shape, validates against `strictEventSchema`. Includes 4 negative cases + a coverage-snapshot test that fails CI if a new `EventType` is added without a schema entry.

Wire-vs-types drift documented in the schema (intentional; not changing the wire contract here):

- `tool.complete` carries `toolResult` on the wire (see `devscope-plugin/scripts/tool-complete.sh:104`); not in `ToolEventPayload` in shared.
- `salt_version` may be appended to any payload by `send-event.sh:52` in private mode.

## Out of scope (follow-ups)

- Wiring `strictEventSchema` into the `POST /api/events` route handler in place of `z.record(z.unknown())`.
- Cross-repo plugin-side enforcement.
- Reconciling the two flagged drifts (add to shared types or drop from wire).

## Test plan

- [x] `bun test src/routes/__tests__/events.contract.test.ts` → 13 pass / 0 fail (local).
- [ ] CI: Tests / Lint / Type Check / GitGuardian green.
- [ ] CodeRabbit review.

## Provenance

Authored by QA agent; landed by CTO per the [DEV-86](/DEV/issues/DEV-86) / [DEV-87](/DEV/issues/DEV-87) precedent (QA writes the scaffold, CTO commits — QA charter forbids QA from committing).

Refs: [DEV-88](/DEV/issues/DEV-88), [DEV-84](/DEV/issues/DEV-84)

Co-Authored-By: Paperclip <noreply@paperclip.ing>