### PR TITLE
DEV-90: server-derive developerId on POST /api/events

### DIFF
--- a/packages/backend/src/routes/__tests__/events.identity.test.ts
+++ b/packages/backend/src/routes/__tests__/events.identity.test.ts
@@ -237,18 +237,22 @@ const ARBITRARY_DEV_ID = "deadbeef".repeat(8); // 64 hex chars, no email basis
 //   "Mismatched tuples are rejected OR strictly auto-linked under documented
 //    rules."
 //
-// Today's behavior on `main`:
-//   - matched, mismatched, sameOrgForge, arbitrary: route ACCEPTS and stores
-//     the declared developerId verbatim. Only `matched` is correct; the others
-//     are forgery vectors.
-//   - anon: route ACCEPTS without auth.
-//   - expired: indistinguishable from anon at the route level (auth middleware
-//     should have rejected upstream; we assert the route's behavior on the
-//     downstream case where the middleware did not strip the body).
+// Behavior after DEV-90 fix (mode (b), "overwrite-on-insert"):
+//   - matched: route accepts and persists the canonical id.
+//   - mismatched, sameOrgForge, arbitrary: route OVERWRITES the body's
+//     declared developerId with SHA256(authUser.email) before persisting.
+//     The plugin-declared id is treated as advisory and is not stored.
+//     This preserves plugin compatibility for users whose `git config
+//     user.email` diverges from their SaaS account email, and converges
+//     the dual-namespace gap below.
+//   - anon, expired: route REJECTS with 401 — there is no authoritative
+//     auth-user email to derive an identity from, so the event cannot be
+//     attributed.
 //
-// Therefore every non-matched row is expected to FAIL RED until the route
-// either (a) rejects mismatched developerIds, or (b) overwrites the declared
-// id with the canonical SHA256(authUser.email) before persisting.
+// Documented rule (see DEV-90 header comment in events.ts): on POST
+// /api/events the API-key owner's auth-account email is the sole source of
+// identity truth; plugin-declared developerId/Name/Email fields are hints
+// only.
 // ---------------------------------------------------------------------------
 
 type ForgeryCase = {
@@ -283,7 +287,7 @@ const forgeryMatrix: ForgeryCase[] = [
     authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
     declaredDeveloperId: BOB_DEV_ID,
     canonicalDeveloperId: ALICE_DEV_ID,
-    expectation: "reject",
+    expectation: "normalize",
   },
   {
     name: "sameOrgForge: apiKey=A, declared=SHA256(B.email) [B is in A's org]",
@@ -293,7 +297,7 @@ const forgeryMatrix: ForgeryCase[] = [
     canonicalDeveloperId: ALICE_DEV_ID,
     // Same-org membership does not authorize cross-identity event posting.
     // Either reject or normalize to A — never silently store as B.
-    expectation: "reject",
+    expectation: "normalize",
   },
   {
     name: "arbitrary: apiKey=A, declared=opaque hex (no email basis)",
@@ -301,7 +305,7 @@ const forgeryMatrix: ForgeryCase[] = [
     authUser: { id: USER_A.authUserId, name: USER_A.name, email: USER_A.email },
     declaredDeveloperId: ARBITRARY_DEV_ID,
     canonicalDeveloperId: ALICE_DEV_ID,
-    expectation: "reject",
+    expectation: "normalize",
   },
   {
     name: "anon: no apiKey, declared=SHA256(B.email)",

--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -103,12 +103,26 @@ function makeMockSql(
   };
 }
 
+/** sha256("alice@example.com") — must match computeDeveloperId behavior. */
+const ALICE_DEV_ID =
+  "ff8d9819fc0e12bf0d24892e45987e249a28dce836a85cad60e28eaaa8c6d976";
+
+/** Default test user used by buildApp() when no overrides are passed. */
+const DEFAULT_TEST_USER = {
+  id: "user-owner-default",
+  name: "Alice",
+  email: "alice@example.com",
+};
+
 /** A valid event body for POST / */
 function validEvent(overrides: Record<string, unknown> = {}) {
   return {
     id: "evt-1",
     timestamp: "2026-03-03T12:00:00Z",
     sessionId: "sess-1",
+    // Body-declared developerId is treated as advisory by the route; the
+    // server overwrites it with SHA256(authUser.email) on insert (DEV-90).
+    // Keeping an arbitrary value here documents that override.
     developerId: "abc123def456",
     developerName: "Alice",
     developerEmail: "alice@example.com",
@@ -122,28 +136,44 @@ function validEvent(overrides: Record<string, unknown> = {}) {
 
 /**
  * Build a Hono app that optionally sets apiKeyUserId and orgDeveloperIds
- * on context (mimicking auth + orgScope middleware), then mounts the events routes.
+ * on context (mimicking auth + orgScope middleware), then mounts the events
+ * routes.
+ *
+ * DEV-90: POST /api/events now requires an authenticated API-key owner with
+ * an auth email; the route overwrites the body's developerId with
+ * SHA256(authUser.email) before persisting. To keep the bulk of the existing
+ * test suite focused on event-lifecycle behavior rather than auth plumbing,
+ * we default-inject DEFAULT_TEST_USER. Tests that intentionally exercise the
+ * unauthenticated path opt out by passing `apiKeyUserId: null` and/or
+ * `user: null`.
  */
 function buildApp(
   sql: any,
   opts: {
-    apiKeyUserId?: string;
+    apiKeyUserId?: string | null;
     orgDeveloperIds?: string[];
-    user?: { id?: string; name?: string; email?: string };
+    user?: { id?: string; name?: string; email?: string } | null;
     session?: { activeOrganizationId?: string };
   } = {},
 ) {
   const app = new Hono();
 
+  const apiKeyUserId =
+    opts.apiKeyUserId === null
+      ? undefined
+      : opts.apiKeyUserId ?? DEFAULT_TEST_USER.id;
+  const user =
+    opts.user === null ? undefined : opts.user ?? DEFAULT_TEST_USER;
+
   app.use("/*", async (c, next) => {
-    if (opts.apiKeyUserId !== undefined) {
-      c.set("apiKeyUserId" as never, opts.apiKeyUserId as never);
+    if (apiKeyUserId !== undefined) {
+      c.set("apiKeyUserId" as never, apiKeyUserId as never);
     }
     if (opts.orgDeveloperIds !== undefined) {
       c.set("orgDeveloperIds" as never, opts.orgDeveloperIds as never);
     }
-    if (opts.user !== undefined) {
-      c.set("user" as never, opts.user as never);
+    if (user !== undefined) {
+      c.set("user" as never, user as never);
     }
     if (opts.session !== undefined) {
       c.set("session" as never, opts.session as never);
@@ -272,9 +302,11 @@ describe("POST /events", () => {
     });
 
     expect(mockUpsertDeveloper).toHaveBeenCalledTimes(1);
+    // DEV-90: route overwrites the body's developerId with the canonical
+    // SHA256(authUser.email) before upserting.
     expect(mockUpsertDeveloper).toHaveBeenCalledWith(
       sql,
-      "abc123def456",
+      ALICE_DEV_ID,
       "Alice",
       "alice@example.com",
     );
@@ -294,7 +326,7 @@ describe("POST /events", () => {
     expect(mockCreateSession).toHaveBeenCalledWith(
       sql,
       "sess-1",
-      "abc123def456",
+      ALICE_DEV_ID,
       "/home/user/project",
       "my-project",
       null, // permissionMode not set in default payload
@@ -318,7 +350,7 @@ describe("POST /events", () => {
     expect(mockCreateSession).toHaveBeenCalledWith(
       sql,
       "sess-1",
-      "abc123def456",
+      ALICE_DEV_ID,
       "/home/user/project",
       "my-project",
       "plan",
@@ -533,24 +565,46 @@ describe("POST /events", () => {
     });
 
     expect(mockAutoLinkDeveloperToOrg).toHaveBeenCalledTimes(1);
+    // DEV-90: autoLink uses the canonical SHA256(authUser.email), not the
+    // body-declared developerId.
     expect(mockAutoLinkDeveloperToOrg).toHaveBeenCalledWith(
       sql,
       "user-owner-1",
-      "abc123def456",
+      ALICE_DEV_ID,
     );
   });
 
-  test("does NOT call autoLinkDeveloperToOrg when apiKeyUserId is absent", async () => {
+  test("rejects with 401 when apiKeyUserId is absent (DEV-90)", async () => {
     const sql = makeMockSql();
-    const app = buildApp(sql); // no apiKeyUserId
+    // Opt out of the default-injected auth context.
+    const app = buildApp(sql, { apiKeyUserId: null, user: null });
 
-    await app.request("/", {
+    const res = await app.request("/", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(validEvent()),
     });
 
+    expect(res.status).toBe(401);
     expect(mockAutoLinkDeveloperToOrg).not.toHaveBeenCalled();
+    expect(mockInsertEvent).not.toHaveBeenCalled();
+  });
+
+  test("rejects with 401 when authenticated user has no email (DEV-90)", async () => {
+    const sql = makeMockSql();
+    const app = buildApp(sql, {
+      apiKeyUserId: "user-owner-1",
+      user: { id: "user-owner-1", name: "Alice" }, // missing email
+    });
+
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(validEvent()),
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockInsertEvent).not.toHaveBeenCalled();
   });
 
   // -----------------------------------------------------------------------
@@ -849,7 +903,7 @@ describe("POST /events", () => {
   // Optional developerEmail
   // -----------------------------------------------------------------------
 
-  test("defaults developerEmail to empty string when omitted", async () => {
+  test("ignores body's developerEmail and uses auth-user email (DEV-90)", async () => {
     const sql = makeMockSql();
     const app = buildApp(sql);
 
@@ -862,11 +916,14 @@ describe("POST /events", () => {
       body: JSON.stringify(event),
     });
 
+    // DEV-90: developerEmail is sourced from the API-key owner's auth account,
+    // not the request body. zValidator's optional/default-empty fallback is
+    // intentionally bypassed by the overwrite.
     expect(mockUpsertDeveloper).toHaveBeenCalledWith(
       sql,
-      "abc123def456",
+      ALICE_DEV_ID,
       "Alice",
-      "",
+      "alice@example.com",
     );
   });
 
@@ -995,7 +1052,8 @@ describe("POST /events/hook", () => {
 
   test("rejects when API key auth is missing", async () => {
     const sql = makeMockSql();
-    const app = buildApp(sql); // no apiKeyUserId, no user
+    // Opt out of buildApp's default-injected auth context.
+    const app = buildApp(sql, { apiKeyUserId: null, user: null });
 
     const res = await app.request("/hook?event=notification", {
       method: "POST",

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -216,24 +216,50 @@ export function eventsRoutes(sql: SQL) {
     const event = c.req.valid("json") as unknown as DevscopeEvent;
     event.timestamp = sanitizeTimestamp(event.timestamp);
 
+    // Identity-trust gate (DEV-90). The plugin declares a developerId in the
+    // body computed locally as SHA256(git config user.email). The route can
+    // not trust that on its own — without verification, any holder of a valid
+    // API key could post events under any developerId of their choosing, and
+    // the same human running with a divergent git/SaaS email lands in two
+    // distinct developer rows (one per ingestion path).
+    //
+    // Rule (overwrite-on-insert):
+    //   1. Require API-key auth + an auth-user email; otherwise 401.
+    //   2. Compute the canonical developerId server-side from the API-key
+    //      owner's auth-account email and OVERWRITE the body's identity
+    //      fields before persisting. The plugin-declared developerId,
+    //      developerName, and developerEmail are treated as advisory hints
+    //      and are not stored.
+    //
+    // This converges with /api/events/hook, which already derives identity
+    // server-side, so a single human producing events on either path lands
+    // on one developer row even when their git email and SaaS account email
+    // differ.
+    const apiKeyUserId = c.get("apiKeyUserId" as never) as string | undefined;
+    const authUser = c.get("user" as never) as { id?: string; name?: string; email?: string } | undefined;
+    if (!apiKeyUserId || !authUser?.email) {
+      return c.json({ error: "Event ingestion requires authenticated API key" }, 401);
+    }
+    event.developerId = computeDeveloperId(authUser.email);
+    event.developerEmail = authUser.email;
+    event.developerName =
+      authUser.name && authUser.name.length > 0 ? authUser.name : "Developer";
+
     await upsertDeveloper(sql, event.developerId, event.developerName, event.developerEmail ?? "");
 
-    // Auto-link plugin developer to the API key owner's org
-    const apiKeyUserId = c.get("apiKeyUserId" as never) as string | undefined;
-    if (apiKeyUserId) {
-      // DEV-68: await the org link before any code that queries
-      // organization_developer (privacy_mode_activated logging below and the
-      // broadcast fan-out in runPostInsertHandlers). Otherwise the very first
-      // event from a brand-new developerId is persisted but not broadcast
-      // because the link insert hasn't landed when the lookup runs.
-      // Errors are still caught so a failed link does not abort ingestion.
-      await autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
-        .catch((err) => console.error("[events] autoLinkDeveloperToOrg failed:", err));
-      // autoLinkUserToDeveloper is not on the broadcast critical path; keep
-      // it fire-and-forget so we don't add an extra round-trip per event.
-      autoLinkUserToDeveloper(sql, apiKeyUserId, event.developerId)
-        .catch((err) => console.error("[events] autoLinkUserToDeveloper failed:", err));
-    }
+    // Auto-link the canonical developer to the API key owner's org.
+    // DEV-68: await the org link before any code that queries
+    // organization_developer (privacy_mode_activated logging below and the
+    // broadcast fan-out in runPostInsertHandlers). Otherwise the very first
+    // event from a brand-new developerId is persisted but not broadcast
+    // because the link insert hasn't landed when the lookup runs.
+    // Errors are still caught so a failed link does not abort ingestion.
+    await autoLinkDeveloperToOrg(sql, apiKeyUserId, event.developerId)
+      .catch((err) => console.error("[events] autoLinkDeveloperToOrg failed:", err));
+    // autoLinkUserToDeveloper is not on the broadcast critical path; keep
+    // it fire-and-forget so we don't add an extra round-trip per event.
+    autoLinkUserToDeveloper(sql, apiKeyUserId, event.developerId)
+      .catch((err) => console.error("[events] autoLinkUserToDeveloper failed:", err));
 
     // Check if this event is reactivating an ended session (e.g. after backend restart)
     const [existingSession] = await sql`SELECT status FROM sessions WHERE id = ${event.sessionId}`;


### PR DESCRIPTION
## Summary

Closes the identity-forgery and dual-namespace gaps captured by the DEV-87 QA scaffold (PR #51) and tracked in [DEV-90](/DEV/issues/DEV-90).

- POST /api/events now requires API-key auth + auth-user email (else 401).
- Route OVERWRITES `developerId/Name/Email` with values derived from the API-key owner's auth account before persisting. The plugin-declared values are advisory.
- Converges with POST /api/events/hook (which already derives identity server-side) so a single human producing events on either path lands on one developer row, even when their `git config user.email` differs from their SaaS account email.

Mode chosen: **(b) overwrite-on-insert** — preserves plugin compatibility (the plugin doesn't have to know the user's auth email; the server normalizes).

## Dependency

This PR is **based on `qa/dev-86-output-guardrail` (PR #51)** so the diff cleanly shows only the DEV-90 fix. Should land in order: PR #51 → this PR (or rebase onto main once #51 merges).

## Test plan

- [x] `bun test src/routes/__tests__/events.identity.test.ts` — 8/8 pass (was 2/8 on `main`).
- [x] `bun test src/routes/__tests__/events.test.ts src/routes/__tests__/events.identity.test.ts` — 50/50 pass.
- [ ] CI green.

## Scaffold updates (per issue: "update the scaffold to GREEN as part of the fix")

- `mismatched`, `sameOrgForge`, `arbitrary`: expectation flipped from `"reject"` to `"normalize"` — server now overwrites with canonical id.
- `anon`, `expired`: stay on `"reject"` — now satisfied by the 401 gate.

## Out of scope (per issue)

- Identity derivation (unchanged in both repos).
- Plugin-side changes (the plugin's body is now treated as advisory; no plugin update needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)