### PR TITLE
DEV-95: extend AgentEventPayload with SubagentStop rich fields

### DIFF
--- a/packages/backend/src/utils/__tests__/stripSensitiveFields.test.ts
+++ b/packages/backend/src/utils/__tests__/stripSensitiveFields.test.ts
@@ -24,6 +24,23 @@ describe("stripSensitivePayload", () => {
     expect(result).not.toHaveProperty("responseText");
   });
 
+  test("removes transcriptPath from agent.stop payloads (local fs path must not reach other devs)", () => {
+    const payload = {
+      agentType: "general-purpose",
+      agentId: "abc123",
+      lastMessageLength: 512,
+      transcriptPath: "/home/dev/.claude/transcripts/abc123.jsonl",
+    };
+    const result = stripSensitivePayload(payload);
+
+    expect(result).toEqual({
+      agentType: "general-purpose",
+      agentId: "abc123",
+      lastMessageLength: 512,
+    });
+    expect(result).not.toHaveProperty("transcriptPath");
+  });
+
   test("handles payload with only some sensitive keys", () => {
     const payload = {
       toolName: "read",

--- a/packages/backend/src/utils/stripSensitiveFields.ts
+++ b/packages/backend/src/utils/stripSensitiveFields.ts
@@ -13,6 +13,10 @@ export function stripSensitivePayload(payload: Record<string, unknown>): Record<
   delete stripped.promptText;
   delete stripped.toolInput;
   delete stripped.responseText;
+  // transcriptPath is a local filesystem path. Fine to store in DB for the
+  // event author's own correlation, but must not be broadcast to other devs
+  // on the shared WebSocket feed. (CodeRabbit #54 inline comment.)
+  delete stripped.transcriptPath;
   return stripped;
 }
 

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -109,6 +109,14 @@ export interface AgentEventPayload {
   agentType: string;
   agentId: string;
   parentAgentId?: string | null;
+  // SubagentStop only: length of the agent's last assistant message in chars.
+  // We never store the raw message body — privacy-preserving signal that lets
+  // us reason about subagent verbosity/output volume without surfacing content.
+  lastMessageLength?: number;
+  // SubagentStop only: local filesystem path to the agent's transcript JSONL.
+  // Stored for local correlation (e.g. extracting token usage from the same
+  // transcript later); never surfaced as raw to other developers.
+  transcriptPath?: string;
 }
 
 export interface ResponsePayload {


### PR DESCRIPTION
## Summary

Extends `AgentEventPayload` (shared) with two optional fields produced by Claude Code's `SubagentStop` hook:

- `lastMessageLength?: number` — character count of the subagent's last assistant message. **Length only — never the raw body** (privacy-preserving signal that lets us reason about subagent verbosity / output volume without surfacing message content).
- `transcriptPath?: string` — local-fs path to the subagent's transcript JSONL. Stored as metadata; never surfaced as raw to other developers.

Plugin counterpart: [DowLucas/devscope-plugin#feat/dev-95-subagent-stop-rich-fields](https://github.com/DowLucas/devscope-plugin/tree/feat/dev-95-subagent-stop-rich-fields) — `agent-stop.sh` reads `last_assistant_message` / `agent_transcript_path` and emits the new fields.

Backend persistence: no schema change needed. The `events.payload` column is `jsonb` and the validator is `z.record(z.unknown())`, so the new optional fields flow through unchanged.

## Privacy / mission check

- ✅ Length only. Plugin-side test confirms raw message body never appears in the emitted payload.
- ✅ Transcript path is local fs only and is not surfaced raw on the team-visible WebSocket feed (event broadcasts already pass through `stripSensitivePayload`).
- ✅ No leaderboard / per-developer comparison surface — this is per-subagent verbosity metadata.

Closes DowLucas/devscope#4 (shared half).

## Test plan

- [x] Smoke-tested payload generation: rich fields included when present, omitted when absent, raw body never serialized.
- [ ] Reviewer: confirm `payload: z.record(z.unknown())` ingestion path (no Zod schema change required).
- [ ] Reviewer: cross-check plugin PR for length-only emission.

🤖 Co-Authored-By: Paperclip <noreply@paperclip.ing>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight message-length signal to event payloads for improved telemetry.

* **Privacy / Bug Fixes**
  * Local transcript file paths are now excluded from shared event feeds to protect sensitive local data.

* **Tests**
  * Added tests to verify sensitive transcript paths are stripped while preserving other event fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->