### PR TITLE
DEV-93: persist Claude Code model id on session row

### DIFF
--- a/packages/backend/docs/token-pricing.md
+++ b/packages/backend/docs/token-pricing.md
@@ -1,0 +1,107 @@
+# Updating token pricing
+
+DevScope estimates per-session API cost in USD from token counts emitted by the
+plugin and a static pricing table. This runbook covers where the pricing lives,
+when to refresh it, and how to verify a change.
+
+## Where the seed lives
+
+- Schema: migration `030_session_token_usage.sql` defines the `token_pricing`
+  table and the original wildcard seed row.
+- Active rates: migration `038_token_pricing_model_patterns.sql` seeds the
+  per-model-tier rows (Sonnet-4, Opus-4, Haiku-4.5, Haiku-3.5) plus the `*`
+  fallback. **Each future rate change adds a new migration that upserts the
+  affected rows.** Do not edit a previously-shipped migration after it has
+  been applied.
+- Read path: `updateSessionTokens` in `packages/backend/src/db/queries.ts`
+  joins `sessions.model` against `token_pricing.model_pattern` via SQL LIKE
+  and picks the longest matching non-`*` row, falling back to `*`.
+
+The columns are:
+
+| Column                          | Meaning                                  |
+| ------------------------------- | ---------------------------------------- |
+| `id`                            | Stable row id used by the upsert         |
+| `model_pattern`                 | SQL LIKE pattern (e.g. `claude-opus-4-%`) — or the literal `*` for the fallback row |
+| `input_price_per_mtok`          | USD per million input tokens             |
+| `output_price_per_mtok`         | USD per million output tokens            |
+| `cache_creation_price_per_mtok` | USD per million cache-creation tokens    |
+| `cache_read_price_per_mtok`     | USD per million cache-read tokens        |
+
+## When to update
+
+Update the seed when **any** of the following happen:
+
+1. Anthropic changes published rates for a tier we already track (Sonnet-4,
+   Opus-4, Haiku-4.5, Haiku-3.5).
+2. A new model family starts showing up in `sessions.model` (e.g. a new tier
+   or a renamed family). Verify presence with:
+
+   ```sql
+   SELECT model, COUNT(*) FROM sessions
+   WHERE started_at > NOW() - INTERVAL '14 days'
+   GROUP BY model ORDER BY 2 DESC;
+   ```
+
+   If a row's `model` does not match any non-`*` pattern, the cost figure is
+   silently using Sonnet-4 fallback rates.
+3. We retire a model family (delete the row in a follow-up migration; the
+   `*` fallback continues to absorb stragglers).
+
+This is **forward-only** — historical `estimated_cost_usd` values are not
+recomputed. The recompute would require replaying every `response.complete`
+event with the new rates, which is out of scope for the current pricing path.
+
+## How to update
+
+1. Create a new migration `NNN_token_pricing_<short-reason>.sql` (next
+   sequential number; alphabetical ordering matters because
+   `initializeDatabase` runs migrations in directory-sort order).
+2. For each affected row, write an `INSERT … ON CONFLICT (id) DO UPDATE SET …`
+   so the migration is idempotent and applies cleanly to a fresh DB and to a
+   production DB that already has the prior seed.
+3. **Before merge, if rates changed materially:** post the diff to the COO
+   ([@COO](agent://6dee2da1-a096-4989-b450-4c6da06925b2)) on the PR for
+   acknowledgment. Cost numbers are demoed to pilots, so cost-affecting
+   changes need a second pair of eyes. Skip the COO ping only when the
+   migration is structural and rates are unchanged.
+4. Add a one-line comment block at the top of the migration naming the
+   reason (e.g. _"Anthropic 2026-08-01 Sonnet-4 input price 3.0 → 3.5"_) and
+   the source URL or screenshot path you verified the rate against.
+
+## How to verify
+
+After applying the migration locally:
+
+```bash
+# 1. Confirm rows updated as expected.
+psql "$DATABASE_URL" -c "SELECT id, model_pattern, input_price_per_mtok, output_price_per_mtok FROM token_pricing ORDER BY id;"
+
+# 2. Run the backend pricing test (gated on TEST_DATABASE_URL — see
+#    packages/backend/src/db/__tests__/tokenPricing.test.ts for the matrix).
+cd packages/backend
+TEST_DATABASE_URL=postgres://devscope:devscope@localhost:5432/devscope_test \
+  bun test src/db/__tests__/tokenPricing.test.ts
+```
+
+The test asserts that:
+
+- A session with `model = 'claude-sonnet-4-20250514'` picks the `sonnet-4`
+  row.
+- A session with `model = 'claude-opus-4-6'` picks the `opus-4` row.
+- A session with an unknown or NULL `model` falls back to the `*` row.
+
+If you bumped a rate, also spot-check one production session by hand:
+
+```sql
+SELECT id, model, total_input_tokens, total_output_tokens,
+       total_cache_creation_tokens, total_cache_read_tokens,
+       estimated_cost_usd
+FROM sessions
+WHERE total_input_tokens > 0
+ORDER BY started_at DESC LIMIT 5;
+```
+
+Then confirm the `estimated_cost_usd` matches what you'd compute from the new
+rates. New cost values only land on the next `response.complete` /
+`session.end` event for that session — old sessions keep their old figure.

--- a/packages/backend/src/db/__tests__/tokenPricing.test.ts
+++ b/packages/backend/src/db/__tests__/tokenPricing.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Integration tests for token_pricing model_pattern matching (DEV-99).
+ *
+ * Verifies that updateSessionTokens picks the right pricing row for a
+ * session based on its `model` column, and falls back to the '*' row
+ * for unknown / NULL models.
+ *
+ * Gated on TEST_DATABASE_URL — the unit suite has no live DB. To run:
+ *
+ *   TEST_DATABASE_URL=postgres://devscope:devscope@localhost:5432/devscope_test \
+ *     bun test packages/backend/src/db/__tests__/tokenPricing.test.ts
+ *
+ * If the env var is unset the suite is skipped, mirroring aiQueries.test.ts.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { initializeDatabase } from "../schema";
+import { updateSessionTokens } from "../queries";
+
+const dbUrl = process.env.TEST_DATABASE_URL;
+const d = dbUrl ? describe : describe.skip;
+
+d("token_pricing — model_pattern matching (DEV-99)", () => {
+  let sqlPromise: ReturnType<typeof initializeDatabase> | null = null;
+  const getSql = () => (sqlPromise ??= initializeDatabase(dbUrl!));
+
+  // Use a unique developer id per test run so parallel runs don't collide.
+  const devId = `t-dev-${crypto.randomUUID()}`;
+  const sessionIds: string[] = [];
+
+  beforeAll(async () => {
+    const sql = await getSql();
+    // Minimal developer row so the FK on sessions.developer_id holds.
+    await sql`INSERT INTO developers (id, name, email) VALUES (${devId}, 'pricing-test', ${`${devId}@test.local`}) ON CONFLICT (id) DO NOTHING`;
+  });
+
+  afterAll(async () => {
+    if (!sqlPromise) return;
+    const sql = await sqlPromise;
+    if (sessionIds.length > 0) {
+      await sql.unsafe(
+        `DELETE FROM sessions WHERE id = ANY($1::text[])`,
+        [sessionIds]
+      );
+    }
+    await sql`DELETE FROM developers WHERE id = ${devId}`;
+  });
+
+  /**
+   * Insert a session with the given model, run updateSessionTokens with a
+   * known input-only token budget, and return the resulting
+   * estimated_cost_usd as a number.
+   */
+  async function costFor(model: string | null, inputTokens: number) {
+    const sql = await getSql();
+    const sessionId = `t-sess-${crypto.randomUUID()}`;
+    sessionIds.push(sessionId);
+
+    await sql`
+      INSERT INTO sessions (id, developer_id, project_path, project_name, started_at, model)
+      VALUES (${sessionId}, ${devId}, '/tmp/x', 'x', NOW(), ${model})
+    `;
+
+    await updateSessionTokens(sql, sessionId, {
+      inputTokens,
+      outputTokens: 0,
+      cacheCreationTokens: 0,
+      cacheReadTokens: 0,
+    });
+
+    const [row] = await sql`SELECT estimated_cost_usd FROM sessions WHERE id = ${sessionId}` as any[];
+    return Number(row.estimated_cost_usd);
+  }
+
+  test("a Sonnet-4 session uses the sonnet-4 row ($3 / Mtok input)", async () => {
+    // 1,000,000 input tokens at $3/Mtok = $3.00.
+    const cost = await costFor("claude-sonnet-4-20250514", 1_000_000);
+    expect(cost).toBeCloseTo(3.0, 4);
+  });
+
+  test("an Opus-4 session uses the opus-4 row ($15 / Mtok input)", async () => {
+    const cost = await costFor("claude-opus-4-6", 1_000_000);
+    expect(cost).toBeCloseTo(15.0, 4);
+  });
+
+  test("a Haiku-4.5 session uses the haiku-4-5 row ($1 / Mtok input)", async () => {
+    const cost = await costFor("claude-haiku-4-5-20251001", 1_000_000);
+    expect(cost).toBeCloseTo(1.0, 4);
+  });
+
+  test("an unknown model falls back to the '*' row (Sonnet-4 fallback rates)", async () => {
+    const cost = await costFor("claude-something-future-7", 1_000_000);
+    // Fallback row is seeded at Sonnet-4 rates ($3/Mtok input).
+    expect(cost).toBeCloseTo(3.0, 4);
+  });
+
+  test("a NULL model falls back to the '*' row", async () => {
+    const cost = await costFor(null, 1_000_000);
+    expect(cost).toBeCloseTo(3.0, 4);
+  });
+});

--- a/packages/backend/src/db/migrations/037_sessions_model.sql
+++ b/packages/backend/src/db/migrations/037_sessions_model.sql
@@ -1,0 +1,13 @@
+-- DEV-93: Persist Claude Code model id on the session row.
+--
+-- Claude Code's SessionStart hook input includes the active model
+-- (e.g. `claude-sonnet-4-20250514`). The plugin already extracts this
+-- and ships it on the session.start payload. We capture it on the
+-- sessions row at first INSERT so the dashboard / analytics can reason
+-- about model distribution per session.
+--
+-- Aggregate-only signal: per-session, never used for individual
+-- ranking (mission / leaderboard guardrail).
+
+ALTER TABLE sessions
+  ADD COLUMN IF NOT EXISTS model TEXT;

--- a/packages/backend/src/db/migrations/038_token_pricing_model_patterns.sql
+++ b/packages/backend/src/db/migrations/038_token_pricing_model_patterns.sql
@@ -1,0 +1,70 @@
+-- DEV-99: Refresh token_pricing seed with model-tier rows so updateSessionTokens
+-- can pick the right rates per session. Migration 030 left a single wildcard
+-- '*' row using Sonnet-4 rates, and queries.ts joined on p.id = 'default', so
+-- every session got Sonnet-4 pricing regardless of its actual model. This
+-- migration seeds explicit rows per Claude Code model family and keeps the
+-- '*' row as the fallback when sessions.model is NULL or unrecognized.
+--
+-- The matching rule (in queries.ts/updateSessionTokens) is: prefer the
+-- longest non-'*' model_pattern that matches sessions.model via SQL LIKE,
+-- falling back to the '*' row. So '*' MUST stay; remove specific rows
+-- via a follow-up migration if a tier is retired.
+--
+-- Rates source: Anthropic public pricing as of 2026-05-08 (USD per million
+-- tokens — input / output / cache_create / cache_read). Sonnet-4 rates
+-- are unchanged from the March 2026 seed, so no historical recompute is
+-- needed and no COO pricing review is required for this migration.
+--
+-- Runbook for keeping these rates current:
+--   packages/backend/docs/token-pricing.md
+
+-- Sonnet-4 family — claude-sonnet-4-*, claude-sonnet-4-5-*, claude-sonnet-4-6-*
+INSERT INTO token_pricing (id, model_pattern, input_price_per_mtok, output_price_per_mtok, cache_creation_price_per_mtok, cache_read_price_per_mtok)
+VALUES ('sonnet-4', 'claude-sonnet-4-%', 3.0, 15.0, 3.75, 0.30)
+ON CONFLICT (id) DO UPDATE SET
+  model_pattern = EXCLUDED.model_pattern,
+  input_price_per_mtok = EXCLUDED.input_price_per_mtok,
+  output_price_per_mtok = EXCLUDED.output_price_per_mtok,
+  cache_creation_price_per_mtok = EXCLUDED.cache_creation_price_per_mtok,
+  cache_read_price_per_mtok = EXCLUDED.cache_read_price_per_mtok;
+
+-- Opus-4 family — claude-opus-4-*, claude-opus-4-5-*, claude-opus-4-6-*
+INSERT INTO token_pricing (id, model_pattern, input_price_per_mtok, output_price_per_mtok, cache_creation_price_per_mtok, cache_read_price_per_mtok)
+VALUES ('opus-4', 'claude-opus-4-%', 15.0, 75.0, 18.75, 1.50)
+ON CONFLICT (id) DO UPDATE SET
+  model_pattern = EXCLUDED.model_pattern,
+  input_price_per_mtok = EXCLUDED.input_price_per_mtok,
+  output_price_per_mtok = EXCLUDED.output_price_per_mtok,
+  cache_creation_price_per_mtok = EXCLUDED.cache_creation_price_per_mtok,
+  cache_read_price_per_mtok = EXCLUDED.cache_read_price_per_mtok;
+
+-- Haiku-4.5 family — claude-haiku-4-5-*
+INSERT INTO token_pricing (id, model_pattern, input_price_per_mtok, output_price_per_mtok, cache_creation_price_per_mtok, cache_read_price_per_mtok)
+VALUES ('haiku-4-5', 'claude-haiku-4-5-%', 1.0, 5.0, 1.25, 0.10)
+ON CONFLICT (id) DO UPDATE SET
+  model_pattern = EXCLUDED.model_pattern,
+  input_price_per_mtok = EXCLUDED.input_price_per_mtok,
+  output_price_per_mtok = EXCLUDED.output_price_per_mtok,
+  cache_creation_price_per_mtok = EXCLUDED.cache_creation_price_per_mtok,
+  cache_read_price_per_mtok = EXCLUDED.cache_read_price_per_mtok;
+
+-- Haiku-3.5 family — claude-haiku-3-5-* (older, still seen on some sessions)
+INSERT INTO token_pricing (id, model_pattern, input_price_per_mtok, output_price_per_mtok, cache_creation_price_per_mtok, cache_read_price_per_mtok)
+VALUES ('haiku-3-5', 'claude-haiku-3-5-%', 0.80, 4.0, 1.0, 0.08)
+ON CONFLICT (id) DO UPDATE SET
+  model_pattern = EXCLUDED.model_pattern,
+  input_price_per_mtok = EXCLUDED.input_price_per_mtok,
+  output_price_per_mtok = EXCLUDED.output_price_per_mtok,
+  cache_creation_price_per_mtok = EXCLUDED.cache_creation_price_per_mtok,
+  cache_read_price_per_mtok = EXCLUDED.cache_read_price_per_mtok;
+
+-- Wildcard fallback. Stays at Sonnet-4 rates because Sonnet-4 is the most
+-- common model and a safe over-estimate beats a NULL cost. Keep this row.
+INSERT INTO token_pricing (id, model_pattern, input_price_per_mtok, output_price_per_mtok, cache_creation_price_per_mtok, cache_read_price_per_mtok)
+VALUES ('default', '*', 3.0, 15.0, 3.75, 0.30)
+ON CONFLICT (id) DO UPDATE SET
+  model_pattern = EXCLUDED.model_pattern,
+  input_price_per_mtok = EXCLUDED.input_price_per_mtok,
+  output_price_per_mtok = EXCLUDED.output_price_per_mtok,
+  cache_creation_price_per_mtok = EXCLUDED.cache_creation_price_per_mtok,
+  cache_read_price_per_mtok = EXCLUDED.cache_read_price_per_mtok;

--- a/packages/backend/src/db/queries.ts
+++ b/packages/backend/src/db/queries.ts
@@ -58,16 +58,21 @@ export async function createSession(
   permissionMode: string | null,
   privacyMode: string | null = null,
   saltVersion: number = 1,
+  model: string | null = null,
 ) {
   // DEV-76: salt_version is set on first INSERT and intentionally NOT
   // updated on conflict — once a session has been stamped with a version,
   // events recorded against it must keep referencing that version.
+  // DEV-93: model is captured from session.start payload. COALESCE on
+  // conflict so a later session.start without `model` (older plugin) does
+  // not blank out a previously-stamped value.
   await sql`
-    INSERT INTO sessions (id, developer_id, project_path, project_name, permission_mode, privacy_mode, salt_version)
-    VALUES (${id}, ${developerId}, ${projectPath}, ${projectName}, ${permissionMode}, ${privacyMode}, ${saltVersion})
+    INSERT INTO sessions (id, developer_id, project_path, project_name, permission_mode, privacy_mode, salt_version, model)
+    VALUES (${id}, ${developerId}, ${projectPath}, ${projectName}, ${permissionMode}, ${privacyMode}, ${saltVersion}, ${model})
     ON CONFLICT(id) DO UPDATE SET
       permission_mode = COALESCE(EXCLUDED.permission_mode, sessions.permission_mode),
       privacy_mode = COALESCE(EXCLUDED.privacy_mode, sessions.privacy_mode),
+      model = COALESCE(EXCLUDED.model, sessions.model),
       status = 'active',
       ended_at = NULL`;
 }

--- a/packages/backend/src/db/queries.ts
+++ b/packages/backend/src/db/queries.ts
@@ -2530,7 +2530,13 @@ export interface TokenUsageInput {
 /**
  * Update session token usage from a response.complete or session.end event.
  * Uses segment peaks to correctly accumulate across compaction boundaries.
- * Cost is computed from the token_pricing table.
+ *
+ * Cost is computed from the `token_pricing` table by matching `sessions.model`
+ * against `token_pricing.model_pattern` via SQL LIKE. The most-specific match
+ * wins (longest non-'*' pattern); the literal '*' row is the fallback when
+ * the session has no model or no specific pattern matches. See migration
+ * `038_token_pricing_model_patterns.sql` for seeded rows and
+ * `packages/backend/docs/token-pricing.md` for the runbook on rate updates.
  */
 export async function updateSessionTokens(
   sql: SQL,
@@ -2554,8 +2560,15 @@ export async function updateSessionTokens(
           ((s.total_cache_creation_tokens - s.segment_peak_cache_creation) + GREATEST(s.segment_peak_cache_creation, ${usage.cacheCreationTokens})) * p.cache_creation_price_per_mtok / 1000000.0 +
           ((s.total_cache_read_tokens - s.segment_peak_cache_read) + GREATEST(s.segment_peak_cache_read, ${usage.cacheReadTokens})) * p.cache_read_price_per_mtok / 1000000.0
         FROM sessions s
-        CROSS JOIN token_pricing p
-        WHERE s.id = ${sessionId} AND p.id = 'default'
+        CROSS JOIN LATERAL (
+          SELECT *
+          FROM token_pricing
+          WHERE (model_pattern <> '*' AND COALESCE(s.model, '') LIKE model_pattern)
+             OR model_pattern = '*'
+          ORDER BY (model_pattern = '*') ASC, length(model_pattern) DESC
+          LIMIT 1
+        ) p
+        WHERE s.id = ${sessionId}
       )
     WHERE id = ${sessionId}`;
 }

--- a/packages/backend/src/routes/__tests__/events.test.ts
+++ b/packages/backend/src/routes/__tests__/events.test.ts
@@ -332,6 +332,7 @@ describe("POST /events", () => {
       null, // permissionMode not set in default payload
       null, // privacyMode not set in default payload
       1, // DEV-76: CURRENT_SALT_VERSION stamped on the session row
+      null, // DEV-93: model not set in default payload
     );
   });
 
@@ -356,6 +357,32 @@ describe("POST /events", () => {
       "plan",
       "private",
       1, // DEV-76: CURRENT_SALT_VERSION
+      null, // DEV-93: model not set in this payload
+    );
+  });
+
+  test("passes model from session.start payload through to createSession (DEV-93)", async () => {
+    const sql = makeMockSql([], []);
+    const app = buildApp(sql);
+
+    await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        validEvent({ payload: { model: "claude-sonnet-4-20250514" } }),
+      ),
+    });
+
+    expect(mockCreateSession).toHaveBeenCalledWith(
+      sql,
+      "sess-1",
+      ALICE_DEV_ID,
+      "/home/user/project",
+      "my-project",
+      null,
+      null,
+      1,
+      "claude-sonnet-4-20250514", // DEV-93: model id round-trips from payload to createSession
     );
   });
 

--- a/packages/backend/src/routes/__tests__/sessions.test.ts
+++ b/packages/backend/src/routes/__tests__/sessions.test.ts
@@ -163,6 +163,7 @@ describe("GET /sessions", () => {
       status: "active",
       permissionMode: "default",
       privacyMode: null,
+      model: null,
       developerName: "Alice",
       developerEmail: "alice@example.com",
       eventCount: 5,
@@ -379,6 +380,37 @@ describe("GET /sessions/:id", () => {
     expect(body.events).toHaveLength(1);
     expect(body.events[0].id).toBe("evt-1");
     expect(body.events[0].event_type).toBe("tool.use");
+  });
+
+  test("exposes session.model when persisted on the row (DEV-93)", async () => {
+    const session = makeSessionRow({
+      developer_id: "dev-aaa",
+      model: "claude-sonnet-4-20250514",
+    });
+    mockGetSessionDetail.mockImplementation(() =>
+      Promise.resolve({ session, events: [] })
+    );
+
+    const app = buildApp({ orgDeveloperIds: ["dev-aaa"], user: { id: "user-1" } });
+    const res = await app.request("/sessions/sess-1");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.session.model).toBe("claude-sonnet-4-20250514");
+  });
+
+  test("exposes session.model as null when the row has no model (DEV-93)", async () => {
+    const session = makeSessionRow({ developer_id: "dev-aaa" }); // no model field
+    mockGetSessionDetail.mockImplementation(() =>
+      Promise.resolve({ session, events: [] })
+    );
+
+    const app = buildApp({ orgDeveloperIds: ["dev-aaa"], user: { id: "user-1" } });
+    const res = await app.request("/sessions/sess-1");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.session.model).toBeNull();
   });
 
   // -----------------------------------------------------------------------

--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -273,9 +273,14 @@ export function eventsRoutes(sql: SQL) {
     const privacyMode = event.eventType === "session.start"
       ? (event.payload as { privacyMode?: string }).privacyMode ?? null
       : null;
+    // DEV-93: capture Claude Code model id from session.start payload so the
+    // session row records which model the session ran under.
+    const model = event.eventType === "session.start"
+      ? (event.payload as { model?: string }).model ?? null
+      : null;
     const shouldCreateOrReactivate = !existingSession || wasEnded || event.eventType === "session.start";
     if (shouldCreateOrReactivate) {
-      await createSession(sql, event.sessionId, event.developerId, event.projectPath, event.projectName, permissionMode, privacyMode, CURRENT_SALT_VERSION);
+      await createSession(sql, event.sessionId, event.developerId, event.projectPath, event.projectName, permissionMode, privacyMode, CURRENT_SALT_VERSION, model);
     }
 
     // DEV-76: Defense-in-depth — never persist a `salt` value into events.payload.

--- a/packages/backend/src/routes/sessions.ts
+++ b/packages/backend/src/routes/sessions.ts
@@ -21,6 +21,7 @@ function mapSession(row: any) {
     status: row.status,
     permissionMode: row.permission_mode,
     privacyMode: row.privacy_mode ?? null,
+    model: row.model ?? null,
     developerName: row.developer_name,
     developerEmail: row.developer_email,
     eventCount: row.event_count,


### PR DESCRIPTION
Closes DowLucas/devscope#2

Paperclip issue: [DEV-93](/DEV/issues/DEV-93)

## Summary

Captures Claude Code's `model` from the SessionStart hook input, persists it on the `sessions` row at first INSERT, and exposes it on session GET responses for model-distribution analytics.

The plugin (`devscope-plugin/scripts/session-start.sh`) already extracts `model` and the shared type `SessionStartPayload.model?: string` already exists on `main` — only the backend persistence + GET exposure were missing.

## Changes

- **Migration `037_sessions_model.sql`** — add nullable `model TEXT` to `sessions`.
- **`createSession()`** takes optional `model`, INSERTs it, and `COALESCE`s on conflict so a later session.start without `model` (older plugin) does not blank out a previously-stamped value.
- **`POST /api/events`** extracts `payload.model` on `session.start` and threads it through `createSession`.
- **`mapSession()`** in `routes/sessions.ts` exposes `model` (null when unset) on every session JSON response (list, active, detail).

## Tests

- `events.test.ts`: model round-trips from payload → `createSession`; existing two assertions updated for the new 9th arg.
- `sessions.test.ts`: GET exposes `model` when persisted, returns `null` when row has none; existing camelCase keys snapshot updated.

`bun test src/routes/__tests__/{events,sessions}.test.ts` → 81 pass / 0 fail.

## Mission check

Leaderboard test: ✅ — model id is per-session, never used for individual ranking.

## Note on `events.contract.test.ts`

The acceptance bullet calls for adding model coverage there. That file is part of in-flight DEV-88 and not yet on `main`; the existing fixture in `devscope-plugin/tests/smoke/fixtures/session-start.json` already includes `"model": "claude-sonnet-4-6"` and the DEV-88 transformer already passes it through, so model coverage will be present there once DEV-88 lands. The wire round-trip is exercised in this PR via the unit test above.