### PR TITLE
DEV-98: token tracking — mission audit + leaderboard regression coverage

### DIFF
--- a/packages/backend/src/routes/__tests__/insights.test.ts
+++ b/packages/backend/src/routes/__tests__/insights.test.ts
@@ -10,10 +10,14 @@ import { dbStubs, developerLinkStubs } from "../../__test_helpers__/mockStubs";
 // ---------------------------------------------------------------------------
 
 const mockGetDeveloperActivityOverTime = mock(() => Promise.resolve([] as any[]));
+const mockGetSessionTokenUsageSummary = mock(() => Promise.resolve(null as any));
+const mockGetSessionTokenUsageOverTime = mock(() => Promise.resolve([] as any[]));
 
 mock.module("../../db", () =>
   dbStubs({
     getDeveloperActivityOverTime: mockGetDeveloperActivityOverTime,
+    getSessionTokenUsageSummary: mockGetSessionTokenUsageSummary,
+    getSessionTokenUsageOverTime: mockGetSessionTokenUsageOverTime,
   }),
 );
 
@@ -50,6 +54,27 @@ beforeEach(() => {
   mockGetDeveloperActivityOverTime.mockImplementation(() => Promise.resolve([]));
   mockGetAllDeveloperIdsForUser.mockReset();
   mockGetAllDeveloperIdsForUser.mockImplementation(() => Promise.resolve([]));
+  mockGetSessionTokenUsageSummary.mockReset();
+  mockGetSessionTokenUsageSummary.mockImplementation(() =>
+    Promise.resolve({
+      total_input_tokens: 0,
+      total_output_tokens: 0,
+      total_cache_creation_tokens: 0,
+      total_cache_read_tokens: 0,
+      total_estimated_cost_usd: 0,
+      avg_cost_per_session_usd: 0,
+      cache_hit_rate: 0,
+      sessions_with_token_data: 0,
+      avg_burn_rate: 0,
+      max_burn_rate: 0,
+      sessions_compacted: 0,
+      total_compactions: 0,
+      avg_peak_context_tokens: 0,
+      max_peak_context_tokens: 0,
+    }),
+  );
+  mockGetSessionTokenUsageOverTime.mockReset();
+  mockGetSessionTokenUsageOverTime.mockImplementation(() => Promise.resolve([]));
 });
 
 // ---------------------------------------------------------------------------
@@ -118,5 +143,95 @@ describe("GET /insights/activity (self-or-deny gate)", () => {
 
     expect(res.status).toBe(403);
     expect(mockGetDeveloperActivityOverTime).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /insights/tokens — aggregate-only regression (DEV-98 mission gate)
+//
+// Tokens + cost are an individual productivity proxy. The mission gate
+// (`team workflow visibility, not individual surveillance`) requires these
+// endpoints to return ONLY the org-wide aggregate scoped by `orgDeveloperIds`.
+// They must ignore any `?developerId=` query parameter — there is no per-dev
+// slicing surface, even self-only, for tokens/cost on these routes.
+// If a future change adds developerId support here, the leaderboard guardrail
+// is broken and this test must be the thing that catches it.
+// ---------------------------------------------------------------------------
+
+describe("GET /insights/tokens (aggregate-only mission gate)", () => {
+  test("ignores ?developerId= and queries only by orgDeveloperIds", async () => {
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request(
+      "/insights/tokens?developerId=dev-aaa&days=14",
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetSessionTokenUsageSummary).toHaveBeenCalledTimes(1);
+    // Signature: (sql, days, developerIds[]) — there is no developerId
+    // parameter at all. The `developerId` query string MUST NOT influence
+    // the call, and the developer scope MUST be the full org set.
+    expect(mockGetSessionTokenUsageSummary).toHaveBeenCalledWith(
+      fakeSql,
+      14,
+      ["dev-aaa", "dev-bbb"],
+    );
+    // Defence in depth: the call args must not contain the requested dev id
+    // alone (which would indicate single-dev slicing).
+    const args = mockGetSessionTokenUsageSummary.mock.calls[0];
+    expect(args[2]).toEqual(["dev-aaa", "dev-bbb"]);
+    expect(args[2]).not.toEqual(["dev-aaa"]);
+  });
+
+  test("returns zeroed aggregate (200) when org has no developers, without DB call", async () => {
+    const app = buildApp({ orgDeveloperIds: [], user: { id: "user-1" } });
+
+    const res = await app.request("/insights/tokens?developerId=dev-aaa");
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.total_input_tokens).toBe(0);
+    expect(body.total_estimated_cost_usd).toBe(0);
+    // No developer scope → don't even touch the DB.
+    expect(mockGetSessionTokenUsageSummary).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /insights/tokens/over-time (aggregate-only mission gate)", () => {
+  test("ignores ?developerId= and queries only by orgDeveloperIds", async () => {
+    const app = buildApp({
+      orgDeveloperIds: ["dev-aaa", "dev-bbb"],
+      user: { id: "user-1" },
+    });
+
+    const res = await app.request(
+      "/insights/tokens/over-time?developerId=dev-bbb&days=7",
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetSessionTokenUsageOverTime).toHaveBeenCalledTimes(1);
+    expect(mockGetSessionTokenUsageOverTime).toHaveBeenCalledWith(
+      fakeSql,
+      7,
+      ["dev-aaa", "dev-bbb"],
+    );
+    const args = mockGetSessionTokenUsageOverTime.mock.calls[0];
+    expect(args[2]).not.toEqual(["dev-bbb"]);
+  });
+
+  test("returns empty array (200) without DB call when org has no developers", async () => {
+    const app = buildApp({ orgDeveloperIds: [], user: { id: "user-1" } });
+
+    const res = await app.request(
+      "/insights/tokens/over-time?developerId=dev-bbb",
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([]);
+    expect(mockGetSessionTokenUsageOverTime).not.toHaveBeenCalled();
   });
 });

--- a/packages/backend/src/utils/__tests__/dashboardTokenLeaderboardGuardrail.test.ts
+++ b/packages/backend/src/utils/__tests__/dashboardTokenLeaderboardGuardrail.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+/**
+ * DEV-98 mission-gate regression: cross-package source scan.
+ *
+ * The dashboard package has no test runner, and the dashboard surfaces
+ * tokens + cost in only two intended places:
+ *
+ *   - `components/insights/TokenUsageCards.tsx` — team-aggregate metric cards.
+ *   - `components/insights/charts/TokenUsageChart.tsx` — team-aggregate area
+ *     chart (no developer dimension).
+ *
+ * The mission gate (`team workflow visibility, not individual surveillance`)
+ * forbids any per-developer leaderboard, ranking, or sort on tokens/cost.
+ * This test scans the dashboard source tree for the textual fingerprints
+ * of such a surface so CI flags it the moment someone adds it. The check
+ * is intentionally textual (not AST-based) because the goal is to be the
+ * loudest possible tripwire on a generic shape — false positives are fine
+ * and correctable in code review; a silent false negative is not.
+ *
+ * If a legitimate aggregate-only surface trips this, *narrow the scan*
+ * via the per-line allow-list below — do not weaken the patterns.
+ */
+
+const DASHBOARD_SRC = join(
+  import.meta.dir,
+  "..",
+  "..",
+  "..",
+  "..",
+  "dashboard",
+  "src",
+);
+
+/** File globs (suffix match) that are allowed to mention tokens/cost
+ * alongside per-developer concepts. Only files whose RELATIVE path under
+ * `packages/dashboard/src` ends with one of these suffixes can carry an
+ * allow-list. */
+const ALLOWED_FILES = new Set<string>([
+  // DeveloperDrillDown is the existing self-only primitive (DEV-31). It
+  // does NOT request /insights/tokens — it only fetches activity, tools,
+  // sessions, projects, hourly. If a future change adds tokens to its
+  // hooks, add an explicit per-line entry here AND raise it in the PR.
+  "components/insights/DeveloperDrillDown.tsx",
+  // SessionDetail shows token totals to the session owner only (self-view
+  // gate, DEV-98). Per-session is by definition per-developer; that is
+  // allowed because the gate is enforced at the component level.
+  "components/session/SessionDetail.tsx",
+]);
+
+/** Patterns whose co-occurrence with a token/cost reference on the same
+ * line indicates a leaderboard/ranking/per-dev-slicing surface. */
+const FORBIDDEN_NEIGHBOURS: Array<{ name: string; rx: RegExp }> = [
+  { name: "leaderboard", rx: /\bleaderboard\b/i },
+  { name: "ranking", rx: /\branking\b/i },
+  { name: "topDevelopers", rx: /\btop[_-]?developers?\b/i },
+  { name: "byDeveloper", rx: /\bby[_-]?developer\b/i },
+  { name: "perDeveloper", rx: /\bper[_-]?developer\b/i },
+];
+
+const TOKEN_OR_COST = /\b(token|tokens|cost|costs|burn[_-]?rate|spend)\b/i;
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      // Skip build outputs and node_modules.
+      if (entry === "node_modules" || entry === "dist" || entry === "build") continue;
+      out.push(...walk(full));
+    } else if (/\.(ts|tsx|js|jsx)$/.test(entry)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function relPath(absPath: string): string {
+  return relative(DASHBOARD_SRC, absPath).split(sep).join("/");
+}
+
+function isAllowedFile(rel: string): boolean {
+  for (const suffix of ALLOWED_FILES) {
+    if (rel.endsWith(suffix)) return true;
+  }
+  return false;
+}
+
+describe("dashboard token/cost surfaces — mission-gate guardrail", () => {
+  test("no per-developer leaderboard, ranking, or slicing on tokens or cost", () => {
+    const files = walk(DASHBOARD_SRC);
+    expect(files.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const rel = relPath(file);
+      if (isAllowedFile(rel)) continue;
+
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, idx) => {
+        if (!TOKEN_OR_COST.test(line)) return;
+        for (const { name, rx } of FORBIDDEN_NEIGHBOURS) {
+          if (rx.test(line)) {
+            violations.push(
+              `${rel}:${idx + 1} mentions "${name}" alongside tokens/cost: ${line.trim()}`,
+            );
+          }
+        }
+      });
+    }
+
+    // Helpful failure message: list every offending site.
+    expect(violations).toEqual([]);
+  });
+
+  test("the only insights endpoints called for tokens are the aggregate routes", () => {
+    // Cross-check: the dashboard must hit `/api/insights/tokens` and
+    // `/api/insights/tokens/over-time` — never construct a token endpoint
+    // with a developerId path or query. Catch obvious regressions like
+    // `/api/insights/tokens/${developerId}` or
+    // `/api/insights/tokens?developerId=`.
+    const files = walk(DASHBOARD_SRC);
+    const offenders: string[] = [];
+
+    const PER_DEV_TOKEN_URL =
+      /["'`]\/api\/insights\/tokens(?:\/over-time)?\/\$\{[^}]*develop/i;
+    const TOKEN_QUERY_DEV =
+      /["'`]\/api\/insights\/tokens(?:\/over-time)?\?[^"'`]*\bdeveloper(?:Id)?=/i;
+
+    for (const file of files) {
+      const text = readFileSync(file, "utf8");
+      if (PER_DEV_TOKEN_URL.test(text) || TOKEN_QUERY_DEV.test(text)) {
+        offenders.push(relPath(file));
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/dashboard/src/components/session/SessionDetail.tsx
+++ b/packages/dashboard/src/components/session/SessionDetail.tsx
@@ -132,13 +132,21 @@ export function SessionDetail({ sessionId }: SessionDetailProps) {
               <div className="flex items-center gap-2 text-destructive">
                 {totalFails > 0 && <span>{totalFails} failures</span>}
               </div>
-              {sessionTokens > 0 && (
+              {/*
+                Mission constraint (DEV-98): per-session token totals and cost
+                are self-view only. Org viewers can load another teammate's
+                session card to see project/duration/tool counts (team workflow
+                visibility), but token + cost figures stay private to the
+                session owner — they are an individual productivity proxy and
+                belong on aggregate-only surfaces (TokenUsageCards) instead.
+              */}
+              {isSelfView && sessionTokens > 0 && (
                 <div className="flex items-center gap-2">
                   <Zap className="h-3.5 w-3.5 text-muted-foreground" />
                   <span>{formatTokenCount(sessionTokens)} tokens</span>
                 </div>
               )}
-              {sessionCost > 0 && (
+              {isSelfView && sessionCost > 0 && (
                 <div className="flex items-center gap-2">
                   <DollarSign className="h-3.5 w-3.5 text-muted-foreground" />
                   <span>{formatCost(sessionCost)}</span>


### PR DESCRIPTION
## Summary

Mission-alignment audit of the already-shipped token tracking surfaces (DEV-97 v1 cut, COO-approved 2026-05-08). The shipped feature passes the leaderboard test with one gap that is fixed in this PR.

- Patch `packages/dashboard/src/components/session/SessionDetail.tsx` — per-session token totals + cost are now gated behind `isSelfView`. The component already received `isSelfView` from `/api/sessions/:id`; this PR just stops rendering the token / cost cells when the viewer is not the session owner.
- Add backend regression tests on `GET /api/insights/tokens` and `GET /api/insights/tokens/over-time` asserting they ignore any `?developerId=` query param and only ever scope by `orgDeveloperIds`.
- Add a cross-package code-search guardrail (`packages/backend/src/utils/__tests__/dashboardTokenLeaderboardGuardrail.test.ts`) that scans the dashboard source for the textual fingerprints of a per-developer leaderboard / ranking on tokens or cost. Lighter-weight option from the issue (the dashboard package has no test runner today).

## Audit findings (verify items from the plan)

- [x] **`SessionDetail.tsx` token gating** — was NOT gated. Org viewers could load any teammate's session and see tokens + cost. Patched here behind `isSelfView`. Aggregate surfaces (`TokenUsageCards`, `TokenUsageChart`) are unchanged because they remain team-aggregate.
- [x] **`peak_context_tokens` and `compaction_count`** — both exist. `peak_context_tokens` is migration `031_context_health.sql`; `compaction_count` is migration `026_new_hooks_and_http.sql`. `getSessionTokenUsageSummary` in `packages/backend/src/db/queries.ts` references them correctly. No migration follow-up needed.
- [x] **Sonnet-4 seed pricing in `030_session_token_usage.sql`** — `3.0 / 15.0 / 3.75 / 0.30` per Mtok still matches Anthropic's published Sonnet-4 rates as of 2026-05-08. No change here; rate updates land on the separate DEV-99 pricing subtask.

## Existing self-only primitive

`packages/dashboard/src/components/insights/DeveloperDrillDown.tsx` is the existing self-only per-developer surface (DEV-31). It does **not** request `/insights/tokens` — its `useInsightsData` hooks are scoped to activity, tools, sessions, projects, and hourly. It is allow-listed in the new code-search guardrail and intentionally NOT extended in this PR (per COO: per-developer self-only token rollup is deferred to v2).

## Out of scope

- Pricing model-pattern matching → handled on DEV-99 in parallel.
- A new per-developer self-only token rollup view → COO-deferred to v2; not added.

## Test plan

- [x] `bun test src/routes/__tests__/insights.test.ts` — 8/8 passing locally (4 new token-aggregate tests added).
- [x] `bun test src/utils/__tests__/dashboardTokenLeaderboardGuardrail.test.ts` — 2/2 passing locally.
- [ ] Manual verify: load another teammate's session in the dashboard while signed in as a non-owner — token + cost cells must NOT render. (Hand-off to CTO / future QA; I have not run a browser session against this branch.)

## Issue thread

- [DEV-98](/DEV/issues/DEV-98) — this audit
- [DEV-97](/DEV/issues/DEV-97) — parent, GH#1 token usage tracking shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)