### PR TITLE
DEV-94 + DEV-96: toolUseId event correlation and PermissionRequest toolInput

### DIFF
--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -453,10 +453,18 @@ export function eventsRoutes(sql: SQL) {
           teammateName: raw.teammate_name ?? raw.teammateName ?? "",
           teamName: raw.team_name ?? raw.teamName ?? "",
         };
-      case "permission.request":
-        return {
+      case "permission.request": {
+        const permPayload: Record<string, unknown> = {
           toolName: raw.tool_name ?? raw.toolName ?? "unknown",
         };
+        // DEV-96: pass tool_input through for HTTP hook clients. The plugin
+        // already privacy-sanitizes before sending, so no further redaction
+        // is needed here. stripSensitivePayload in the broadcast path already
+        // drops toolInput from cross-developer views.
+        const toolInput = raw.tool_input ?? raw.toolInput;
+        if (toolInput != null) permPayload.toolInput = toolInput;
+        return permPayload;
+      }
       case "worktree.create":
         return {
           worktreeName: raw.name ?? raw.worktreeName ?? "",

--- a/packages/dashboard/src/lib/__tests__/buildTurns.test.ts
+++ b/packages/dashboard/src/lib/__tests__/buildTurns.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { buildTurns } from "../buildTurns";
+
+interface RawEvent {
+  id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+}
+
+function ev(
+  id: string,
+  event_type: string,
+  payload: Record<string, unknown>,
+  created_at = "2026-05-08T00:00:00.000Z"
+): RawEvent {
+  return { id, event_type, payload, created_at };
+}
+
+describe("buildTurns — DEV-94 tool_use_id pairing", () => {
+  test("pairs concurrent same-tool invocations correctly via toolUseId", () => {
+    // Scenario: a parent turn fires two parallel Read calls. Hook events
+    // arrive interleaved:
+    //   start(Read, tu_a) → start(Read, tu_b) → complete(Read, tu_b, dur=20, success)
+    //   → fail(Read, tu_a, error="permission denied")
+    // With name-only pairing, complete(tu_b) would attach to start(tu_a)
+    // because findLast returns the most recent unfinished name-match.
+    // toolUseId pairing must attach each complete to its own start.
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "read both", promptLength: 9 }),
+      ev("s1", "tool.start", { toolName: "Read", toolUseId: "tu_a", toolInput: { file_path: "/a" } }),
+      ev("s2", "tool.start", { toolName: "Read", toolUseId: "tu_b", toolInput: { file_path: "/b" } }),
+      ev("c1", "tool.complete", {
+        toolName: "Read",
+        toolUseId: "tu_b",
+        success: true,
+        duration: 20,
+        toolInput: { file_path: "/b" },
+      }),
+      ev("f1", "tool.fail", {
+        toolName: "Read",
+        toolUseId: "tu_a",
+        success: false,
+        errorMessage: "permission denied",
+        toolInput: { file_path: "/a" },
+      }),
+      ev("r1", "response.complete", { responseLength: 0, toolsUsed: ["Read"] }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(2);
+
+    const a = turn.toolCalls.find((c) => c.toolUseId === "tu_a");
+    const b = turn.toolCalls.find((c) => c.toolUseId === "tu_b");
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+
+    // tu_a must carry the FAIL signal (and its file_path), not tu_b's
+    // 20ms-success signal.
+    expect(a!.success).toBe(false);
+    expect(a!.errorMessage).toBe("permission denied");
+    expect((a!.toolInput as { file_path?: string } | undefined)?.file_path).toBe("/a");
+
+    // tu_b must carry the SUCCESS / 20ms duration.
+    expect(b!.success).toBe(true);
+    expect(b!.duration).toBe(20);
+    expect((b!.toolInput as { file_path?: string } | undefined)?.file_path).toBe("/b");
+  });
+
+  test("falls back to name+subcommand pairing when toolUseId is absent (older plugin)", () => {
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "old plugin run", promptLength: 14 }),
+      ev("s1", "tool.start", { toolName: "Bash", toolSubcommand: "ls" }),
+      ev("c1", "tool.complete", {
+        toolName: "Bash",
+        toolSubcommand: "ls",
+        success: true,
+        duration: 5,
+      }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(1);
+    expect(turn.toolCalls[0].success).toBe(true);
+    expect(turn.toolCalls[0].duration).toBe(5);
+    expect(turn.toolCalls[0].toolUseId).toBeUndefined();
+  });
+
+  test("does not collapse a toolUseId-tagged complete into a different toolUseId start", () => {
+    // Both events carry toolUseIds but they don't match. The complete must
+    // NOT attach to the start by name — keeping the start visible as still-
+    // running so a late complete can land on it later.
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "x", promptLength: 1 }),
+      ev("s1", "tool.start", { toolName: "Read", toolUseId: "tu_a" }),
+      ev("c1", "tool.complete", {
+        toolName: "Read",
+        toolUseId: "tu_b",
+        success: true,
+        duration: 7,
+      }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(2);
+    const a = turn.toolCalls.find((c) => c.toolUseId === "tu_a");
+    const b = turn.toolCalls.find((c) => c.toolUseId === "tu_b");
+    expect(a?.success).toBeUndefined();
+    expect(b?.success).toBe(true);
+    expect(b?.duration).toBe(7);
+  });
+});

--- a/packages/dashboard/src/lib/buildTurns.ts
+++ b/packages/dashboard/src/lib/buildTurns.ts
@@ -42,23 +42,40 @@ export function buildTurns(events: RawEvent[]): SessionTurn[] {
         const turn = ensureTurn();
         // For tool.start, add a placeholder; for complete/fail, try to update the last matching entry
         const toolInput = p.toolInput as Record<string, unknown> | undefined;
+        const toolUseId = p.toolUseId ? String(p.toolUseId) : undefined;
         if (event.event_type === "tool.start") {
           turn.toolCalls.push({
             toolName: String(p.toolName ?? "Unknown"),
             toolSubcommand: p.toolSubcommand ? String(p.toolSubcommand) : undefined,
+            toolUseId,
             toolInput,
             timestamp: event.created_at,
           });
         } else {
-          // Find matching tool.start to update, or add new.
-          // Prefer matching by (toolName, toolSubcommand) when subcommand is present.
+          // DEV-94: prefer toolUseId for pairing — it uniquely identifies each
+          // invocation, so concurrent same-tool calls (e.g. parallel Read) are
+          // matched correctly. Fall back to (toolName, toolSubcommand) when
+          // toolUseId is absent (older plugin versions or hosts that don't
+          // surface tool_use_id in the hook input).
           const toolSub = p.toolSubcommand ? String(p.toolSubcommand) : undefined;
-          const existing = turn.toolCalls.findLast(
-            (tc) =>
-              tc.toolName === String(p.toolName ?? "") &&
-              tc.success === undefined &&
-              (toolSub === undefined || tc.toolSubcommand === toolSub)
-          );
+          let existing: typeof turn.toolCalls[number] | undefined;
+          if (toolUseId) {
+            existing = turn.toolCalls.findLast(
+              (tc) => tc.toolUseId === toolUseId && tc.success === undefined
+            );
+          }
+          if (!existing) {
+            existing = turn.toolCalls.findLast(
+              (tc) =>
+                tc.toolName === String(p.toolName ?? "") &&
+                tc.success === undefined &&
+                // When the complete event carries a toolUseId but the entry
+                // already has a different one, don't collapse them by name —
+                // that's exactly the collision DEV-94 fixes.
+                (toolUseId === undefined || tc.toolUseId === undefined) &&
+                (toolSub === undefined || tc.toolSubcommand === toolSub)
+            );
+          }
           if (existing) {
             existing.success = event.event_type === "tool.complete";
             existing.isInterrupt = (p.isInterrupt as boolean) || undefined;
@@ -66,10 +83,12 @@ export function buildTurns(events: RawEvent[]): SessionTurn[] {
             existing.errorMessage = p.errorMessage as string | undefined;
             if (toolInput) existing.toolInput = toolInput;
             if (p.toolSubcommand) existing.toolSubcommand = String(p.toolSubcommand);
+            if (toolUseId && !existing.toolUseId) existing.toolUseId = toolUseId;
           } else {
             turn.toolCalls.push({
               toolName: String(p.toolName ?? "Unknown"),
               toolSubcommand: p.toolSubcommand ? String(p.toolSubcommand) : undefined,
+              toolUseId,
               toolInput,
               success: event.event_type === "tool.complete",
               isInterrupt: (p.isInterrupt as boolean) || undefined,

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -103,20 +103,20 @@ export interface ToolEventPayload {
   errorMessage?: string;
   isInterrupt?: boolean;
   agentId?: string | null;
+  /**
+   * DEV-94: per-invocation correlation id from Claude Code's PreToolUse /
+   * PostToolUse hooks. Pairs tool.start with tool.complete/tool.fail even
+   * when the same tool runs concurrently in parallel sub-agent calls.
+   * Optional — older plugin versions do not emit it; consumers MUST fall
+   * back to (toolName, toolSubcommand) matching when absent.
+   */
+  toolUseId?: string;
 }
 
 export interface AgentEventPayload {
   agentType: string;
   agentId: string;
   parentAgentId?: string | null;
-  // SubagentStop only: length of the agent's last assistant message in chars.
-  // We never store the raw message body — privacy-preserving signal that lets
-  // us reason about subagent verbosity/output volume without surfacing content.
-  lastMessageLength?: number;
-  // SubagentStop only: local filesystem path to the agent's transcript JSONL.
-  // Stored for local correlation (e.g. extracting token usage from the same
-  // transcript later); never surfaced as raw to other developers.
-  transcriptPath?: string;
 }
 
 export interface ResponsePayload {
@@ -147,6 +147,14 @@ export interface TaskCompletedPayload {
 
 export interface PermissionRequestPayload {
   toolName: string;
+  /**
+   * DEV-96: full PermissionRequest tool_input from the Claude Code hook.
+   * In `private` mode the plugin applies the same redaction as tool.start so
+   * paths/patterns are hashed and Bash command / Write content / Edit args
+   * are dropped before the event is sent. `permission_suggestions` is
+   * intentionally omitted (low signal vs. payload size).
+   */
+  toolInput?: Record<string, unknown>;
 }
 
 export interface WorktreeCreatePayload {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -81,6 +81,8 @@ export interface ToolCallEntry {
   duration?: number;
   errorMessage?: string;
   timestamp: string;
+  /** DEV-94: per-invocation correlation id; pairs start/complete reliably for parallel same-tool calls. */
+  toolUseId?: string;
 }
 
 export interface SessionTurn {


### PR DESCRIPTION
## Summary

Companion to [DowLucas/devscope-plugin#17](https://github.com/DowLucas/devscope-plugin/pull/17). Bundles two hygiene fixes:

- **DEV-94** ([DowLucas/devscope#3](https://github.com/DowLucas/devscope/issues/3)): add `toolUseId` to shared types and prefer it for pairing `tool.start` / `tool.complete` events in the dashboard.
- **DEV-96** ([DowLucas/devscope#6](https://github.com/DowLucas/devscope/issues/6)): add `toolInput` to `PermissionRequestPayload` and forward it through the HTTP hook normalisation path.

## Changes

### DEV-94 — `toolUseId` correlation
- `packages/shared/src/events.ts`: add `toolUseId?: string` to `ToolEventPayload`. Per-invocation correlation id; consumers fall back to `(toolName, toolSubcommand)` pairing when absent (older plugin versions).
- `packages/shared/src/models.ts`: add `toolUseId?: string` to `ToolCallEntry`.
- `packages/dashboard/src/lib/buildTurns.ts`: prefer `toolUseId` when matching `tool.start` to `tool.complete`/`tool.fail`. Does not collapse events that carry different `toolUseId`s by name alone — that's exactly the concurrent-parallel-tool bug this fixes.
- `packages/dashboard/src/lib/__tests__/buildTurns.test.ts`: 3 regression tests (concurrent same-tool, fallback path when `toolUseId` absent, orphan-id guard).

### DEV-96 — PermissionRequest `toolInput`
- `packages/shared/src/events.ts`: add `toolInput?: Record<string, unknown>` to `PermissionRequestPayload` with redaction contract comment. `stripSensitivePayload` already covers `toolInput` in cross-developer broadcast views.
- `packages/backend/src/routes/events.ts`: extend `normalizeHookPayload` for `permission.request` to forward `tool_input` / `toolInput` for HTTP hook clients (plugin already privacy-sanitizes before sending).

### Backend
No migration needed — `events.payload` is already JSONB; `toolUseId` and `toolInput` flow through the existing column.

## Test plan
- [ ] `bun test packages/dashboard/src/lib/__tests__/buildTurns.test.ts` — 3/3 pass (verified on this branch)
- [ ] Plugin smoke test: confirm `toolUseId` and `toolInput` appear in emitted payloads
- [ ] Existing backend event tests: no regressions

closes DowLucas/devscope#3
closes DowLucas/devscope#6