### PR TITLE
feat(DEV-94,DEV-96): tool_use_id correlation + PermissionRequest toolInput

### DIFF
--- a/packages/backend/src/routes/events.ts
+++ b/packages/backend/src/routes/events.ts
@@ -453,10 +453,17 @@ export function eventsRoutes(sql: SQL) {
           teammateName: raw.teammate_name ?? raw.teammateName ?? "",
           teamName: raw.team_name ?? raw.teamName ?? "",
         };
-      case "permission.request":
+      case "permission.request": {
+        // DEV-96: pass through tool_input when the hook client supplies it.
+        // The plugin already privacy-sanitizes before send; for raw HTTP
+        // hook clients the field is opt-in (typed Record<string, unknown>).
+        // permission_suggestions is intentionally dropped (low signal).
+        const ti = raw.tool_input ?? raw.toolInput;
         return {
           toolName: raw.tool_name ?? raw.toolName ?? "unknown",
+          ...(ti && typeof ti === "object" ? { toolInput: ti } : {}),
         };
+      }
       case "worktree.create":
         return {
           worktreeName: raw.name ?? raw.worktreeName ?? "",

--- a/packages/dashboard/src/lib/__tests__/buildTurns.test.ts
+++ b/packages/dashboard/src/lib/__tests__/buildTurns.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import { buildTurns } from "../buildTurns";
+
+interface RawEvent {
+  id: string;
+  event_type: string;
+  payload: Record<string, unknown>;
+  created_at: string;
+}
+
+function ev(
+  id: string,
+  event_type: string,
+  payload: Record<string, unknown>,
+  created_at = "2026-05-08T00:00:00.000Z"
+): RawEvent {
+  return { id, event_type, payload, created_at };
+}
+
+describe("buildTurns — DEV-94 tool_use_id pairing", () => {
+  test("pairs concurrent same-tool invocations correctly via toolUseId", () => {
+    // Scenario: a parent turn fires two parallel Read calls. Hook events
+    // arrive interleaved:
+    //   start(Read, tu_a) → start(Read, tu_b) → complete(Read, tu_b, dur=20, success)
+    //   → fail(Read, tu_a, error="permission denied")
+    // With name-only pairing, complete(tu_b) would attach to start(tu_a)
+    // because findLast returns the most recent unfinished name-match.
+    // toolUseId pairing must attach each complete to its own start.
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "read both", promptLength: 9 }),
+      ev("s1", "tool.start", { toolName: "Read", toolUseId: "tu_a", toolInput: { file_path: "/a" } }),
+      ev("s2", "tool.start", { toolName: "Read", toolUseId: "tu_b", toolInput: { file_path: "/b" } }),
+      ev("c1", "tool.complete", {
+        toolName: "Read",
+        toolUseId: "tu_b",
+        success: true,
+        duration: 20,
+        toolInput: { file_path: "/b" },
+      }),
+      ev("f1", "tool.fail", {
+        toolName: "Read",
+        toolUseId: "tu_a",
+        success: false,
+        errorMessage: "permission denied",
+        toolInput: { file_path: "/a" },
+      }),
+      ev("r1", "response.complete", { responseLength: 0, toolsUsed: ["Read"] }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(2);
+
+    const a = turn.toolCalls.find((c) => c.toolUseId === "tu_a");
+    const b = turn.toolCalls.find((c) => c.toolUseId === "tu_b");
+    expect(a).toBeDefined();
+    expect(b).toBeDefined();
+
+    // tu_a must carry the FAIL signal (and its file_path), not tu_b's
+    // 20ms-success signal.
+    expect(a!.success).toBe(false);
+    expect(a!.errorMessage).toBe("permission denied");
+    expect((a!.toolInput as { file_path?: string } | undefined)?.file_path).toBe("/a");
+
+    // tu_b must carry the SUCCESS / 20ms duration.
+    expect(b!.success).toBe(true);
+    expect(b!.duration).toBe(20);
+    expect((b!.toolInput as { file_path?: string } | undefined)?.file_path).toBe("/b");
+  });
+
+  test("falls back to name+subcommand pairing when toolUseId is absent (older plugin)", () => {
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "old plugin run", promptLength: 14 }),
+      ev("s1", "tool.start", { toolName: "Bash", toolSubcommand: "ls" }),
+      ev("c1", "tool.complete", {
+        toolName: "Bash",
+        toolSubcommand: "ls",
+        success: true,
+        duration: 5,
+      }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(1);
+    expect(turn.toolCalls[0].success).toBe(true);
+    expect(turn.toolCalls[0].duration).toBe(5);
+    expect(turn.toolCalls[0].toolUseId).toBeUndefined();
+  });
+
+  test("does not collapse a toolUseId-tagged complete into a different toolUseId start", () => {
+    // Both events carry toolUseIds but they don't match. The complete must
+    // NOT attach to the start by name — keeping the start visible as still-
+    // running so a late complete can land on it later.
+    const events: RawEvent[] = [
+      ev("p1", "prompt.submit", { promptText: "x", promptLength: 1 }),
+      ev("s1", "tool.start", { toolName: "Read", toolUseId: "tu_a" }),
+      ev("c1", "tool.complete", {
+        toolName: "Read",
+        toolUseId: "tu_b",
+        success: true,
+        duration: 7,
+      }),
+    ];
+
+    const [turn] = buildTurns(events);
+    expect(turn.toolCalls).toHaveLength(2);
+    const a = turn.toolCalls.find((c) => c.toolUseId === "tu_a");
+    const b = turn.toolCalls.find((c) => c.toolUseId === "tu_b");
+    expect(a?.success).toBeUndefined();
+    expect(b?.success).toBe(true);
+    expect(b?.duration).toBe(7);
+  });
+});

--- a/packages/dashboard/src/lib/buildTurns.ts
+++ b/packages/dashboard/src/lib/buildTurns.ts
@@ -42,23 +42,40 @@ export function buildTurns(events: RawEvent[]): SessionTurn[] {
         const turn = ensureTurn();
         // For tool.start, add a placeholder; for complete/fail, try to update the last matching entry
         const toolInput = p.toolInput as Record<string, unknown> | undefined;
+        const toolUseId = p.toolUseId ? String(p.toolUseId) : undefined;
         if (event.event_type === "tool.start") {
           turn.toolCalls.push({
             toolName: String(p.toolName ?? "Unknown"),
             toolSubcommand: p.toolSubcommand ? String(p.toolSubcommand) : undefined,
+            toolUseId,
             toolInput,
             timestamp: event.created_at,
           });
         } else {
-          // Find matching tool.start to update, or add new.
-          // Prefer matching by (toolName, toolSubcommand) when subcommand is present.
+          // DEV-94: prefer toolUseId for pairing — it uniquely identifies each
+          // invocation, so concurrent same-tool calls (e.g. parallel Read) are
+          // matched correctly. Fall back to (toolName, toolSubcommand) when
+          // toolUseId is absent (older plugin versions or hosts that don't
+          // surface tool_use_id in the hook input).
           const toolSub = p.toolSubcommand ? String(p.toolSubcommand) : undefined;
-          const existing = turn.toolCalls.findLast(
-            (tc) =>
-              tc.toolName === String(p.toolName ?? "") &&
-              tc.success === undefined &&
-              (toolSub === undefined || tc.toolSubcommand === toolSub)
-          );
+          let existing: typeof turn.toolCalls[number] | undefined;
+          if (toolUseId) {
+            existing = turn.toolCalls.findLast(
+              (tc) => tc.toolUseId === toolUseId && tc.success === undefined
+            );
+          }
+          if (!existing) {
+            existing = turn.toolCalls.findLast(
+              (tc) =>
+                tc.toolName === String(p.toolName ?? "") &&
+                tc.success === undefined &&
+                // When the complete event carries a toolUseId but the entry
+                // already has a different one, don't collapse them by name —
+                // that's exactly the collision DEV-94 fixes.
+                (toolUseId === undefined || tc.toolUseId === undefined) &&
+                (toolSub === undefined || tc.toolSubcommand === toolSub)
+            );
+          }
           if (existing) {
             existing.success = event.event_type === "tool.complete";
             existing.isInterrupt = (p.isInterrupt as boolean) || undefined;
@@ -66,10 +83,12 @@ export function buildTurns(events: RawEvent[]): SessionTurn[] {
             existing.errorMessage = p.errorMessage as string | undefined;
             if (toolInput) existing.toolInput = toolInput;
             if (p.toolSubcommand) existing.toolSubcommand = String(p.toolSubcommand);
+            if (toolUseId && !existing.toolUseId) existing.toolUseId = toolUseId;
           } else {
             turn.toolCalls.push({
               toolName: String(p.toolName ?? "Unknown"),
               toolSubcommand: p.toolSubcommand ? String(p.toolSubcommand) : undefined,
+              toolUseId,
               toolInput,
               success: event.event_type === "tool.complete",
               isInterrupt: (p.isInterrupt as boolean) || undefined,

--- a/packages/shared/src/events.ts
+++ b/packages/shared/src/events.ts
@@ -103,6 +103,14 @@ export interface ToolEventPayload {
   errorMessage?: string;
   isInterrupt?: boolean;
   agentId?: string | null;
+  /**
+   * DEV-94: per-invocation correlation id from Claude Code's PreToolUse /
+   * PostToolUse hooks. Pairs tool.start with tool.complete/tool.fail even
+   * when the same tool runs concurrently in parallel sub-agent calls.
+   * Optional — older plugin versions do not emit it; consumers MUST fall
+   * back to (toolName, toolSubcommand) matching when absent.
+   */
+  toolUseId?: string;
 }
 
 export interface AgentEventPayload {
@@ -147,6 +155,12 @@ export interface TaskCompletedPayload {
 
 export interface PermissionRequestPayload {
   toolName: string;
+  // Full PermissionRequest tool_input from the Claude Code hook. In `private`
+  // mode the plugin runs this through the same redaction helper as tool.start,
+  // so paths/patterns are hashed and Bash command / Write content / Edit args
+  // are dropped before the event is sent (DEV-96). `permission_suggestions` is
+  // intentionally omitted per the upstream issue (low signal).
+  toolInput?: Record<string, unknown>;
 }
 
 export interface WorktreeCreatePayload {

--- a/packages/shared/src/models.ts
+++ b/packages/shared/src/models.ts
@@ -81,6 +81,8 @@ export interface ToolCallEntry {
   duration?: number;
   errorMessage?: string;
   timestamp: string;
+  /** DEV-94: per-invocation correlation id; pairs start/complete reliably for parallel same-tool calls. */
+  toolUseId?: string;
 }
 
 export interface SessionTurn {


### PR DESCRIPTION
## Summary

- **DEV-94** (closes DowLucas/devscope#3): Add `toolUseId?: string` to `ToolEventPayload` and `ToolCallEntry`. Update `buildTurns.ts` to prefer `toolUseId`-based pairing for `tool.start`/`tool.complete`/`tool.fail` events — eliminates incorrect matches when the same tool runs in parallel sub-agent calls. Falls back to `(toolName, toolSubcommand)` matching for older plugin versions. New test coverage in `packages/dashboard/src/lib/__tests__/buildTurns.test.ts`.

- **DEV-96** (closes DowLucas/devscope#6): Add `toolInput?: Record<string, unknown>` to `PermissionRequestPayload`. Extend `normalizeHookPayload` in `packages/backend/src/routes/events.ts` to pass through `tool_input` from raw HTTP hook clients. JSONB persistence is automatic; `stripSensitivePayload` already strips `toolInput` from cross-developer views. `permission_suggestions` intentionally omitted.

## Changes

| File | Owner |
|---|---|
| `packages/shared/src/events.ts` | DEV-94 (`toolUseId`) + DEV-96 (`toolInput`) |
| `packages/shared/src/models.ts` | DEV-94 (`toolUseId` on `ToolCallEntry`) |
| `packages/dashboard/src/lib/buildTurns.ts` | DEV-94 (toolUseId-based pairing) |
| `packages/dashboard/src/lib/__tests__/buildTurns.test.ts` | DEV-94 (new tests) |
| `packages/backend/src/routes/events.ts` | DEV-96 (`normalizeHookPayload` extension) |

## Test plan

- [ ] `bun test packages/dashboard/src/lib/__tests__/buildTurns.test.ts` passes
- [ ] Type-check: `bunx tsc --noEmit` shows no new errors in changed files
- [ ] End-to-end: send `permission.request` event with `toolInput` to POST `/api/events`; confirm `200` and payload persisted in `events.payload` JSONB
- [ ] Cross-developer view: non-owner can't see `toolInput` (`stripSensitivePayload` strips it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)